### PR TITLE
Fix main source file url in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "bodymovin",
   "description": "After Effects plugin for exporting animations to SVG + JavaScript or canvas + JavaScript",
-  "main": "./build/player/bodymovin.js",
+  "main": "./build/player/lottie.js",
   "authors": [
     "hernan <bodymovin@users.noreply.github.com>"
   ],


### PR DESCRIPTION
If automated tasks adds the the scripts when building the project, some projects use the main parameter in the bower.json, and currently is named bodymovin.js instead of lottie.js