### PR TITLE
Avoid "tainted canvas" with images on remote servers

### DIFF
--- a/player/js/elements/canvasElements/CVImageElement.js
+++ b/player/js/elements/canvasElements/CVImageElement.js
@@ -1,6 +1,7 @@
 function CVImageElement(data, globalData, comp){
     this.failed = false;
     this.img = new Image();
+    this.img.crossOrigin = 'anonymous';
     this.assetData = globalData.getAssetData(data.refId);
     this.initElement(data,globalData,comp);
     this.globalData.addPendingElement();


### PR DESCRIPTION
Adding a simple {crossOrigin='anonymous'} property to images makes them avoid this issue:
https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image#What_is_a_tainted_canvas

I put up an example, which uses a build based on this PR to illustrate. It uses `canvas.toDataURL()` and sets the output as the background image every 2 seconds (looks like a ghosting effect). Without crossOrigin this would not work and instead throw an error.

https://jsfiddle.net/jqo4s50w/

It is only needed for the canvas renderer afaik, so I didn't change the image loader for the hybrid renderer.