### PR TITLE
Fix assets error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ you can also use addEventListener with the following events:
 - segmentStart
 - config_ready (when initial config is done)
 - data_ready (when all parts of the animation have been loaded)
+- data_failed (when part of the animation can not be loaded)
 - loaded_images (when all image loads have either succeeded or errored)
 - DOMLoaded (when elements have been added to the DOM)
 - destroy

--- a/player/js/animation/AnimationItem.js
+++ b/player/js/animation/AnimationItem.js
@@ -82,7 +82,9 @@ AnimationItem.prototype.setParams = function(params) {
         this.fileName = params.path.substr(params.path.lastIndexOf('/')+1);
         this.fileName = this.fileName.substr(0,this.fileName.lastIndexOf('.json'));
 
-        assetLoader.load(params.path, this.configAnimation.bind(this));
+        assetLoader.load(params.path, this.configAnimation.bind(this), function() {
+            this.trigger('data_failed');
+        }.bind(this));
     }
 };
 
@@ -166,7 +168,9 @@ AnimationItem.prototype.loadNextSegment = function() {
     this.timeCompleted = segment.time * this.frameRate;
     var segmentPath = this.path+this.fileName+'_' + this.segmentPos + '.json';
     this.segmentPos += 1;
-    assetLoader.load(segmentPath, this.includeLayers.bind(this));
+    assetLoader.load(segmentPath, this.includeLayers.bind(this), function() {
+        this.trigger('data_failed');
+    }.bind(this));
 };
 
 AnimationItem.prototype.loadSegments = function() {

--- a/player/js/utils/asset_loader.js
+++ b/player/js/utils/asset_loader.js
@@ -10,7 +10,7 @@ var assetLoader = (function(){
 		}
 	}
 
-	function loadAsset(path, callback, error) {
+	function loadAsset(path, callback, errorCallback) {
 		var response;
 		var xhr = new XMLHttpRequest();
 		xhr.open('GET', path, true);
@@ -27,8 +27,8 @@ var assetLoader = (function(){
 	            		response = formatResponse(xhr);
 	            		callback(response);
 	                }catch(err){
-	                	if(error_callback) {
-	                		error_callback(err);
+	                	if(errorCallback) {
+	                		errorCallback(err);
 	                	}
 	                }
 	            }


### PR DESCRIPTION
Currently, library doesn't provide any opportunuty to detect that animation configuration is failed, so I added new event for this case.

Before changes, asset_loader contains undeclared variable error_callback and there is no usage of loadAsset third argument.