### PR TITLE
Removing unnecessary files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,5 @@ esprima/
 bodymovinCert.p12
 ZXPSignCmd.exe
 signer.bat
+gifs/
+build/extension/

--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ ZXPSignCmd.exe
 signer.bat
 gifs/
 build/extension/
+projects/


### PR DESCRIPTION
This should save around 6.7 MB in download size, by removing:
 - all **Gifs** (4.2 MB)
 - the After Effects Extension (2.2 MB)
 - the projects folder (300 KB)