### PR TITLE
fix: i in for loop undefined

### DIFF
--- a/player/js/utils/expressions/ExpressionValueFactory.js
+++ b/player/js/utils/expressions/ExpressionValueFactory.js
@@ -62,7 +62,7 @@ var ExpressionPropertyInterface = (function() {
             if (property.k) {
                 property.getValue();
             }
-            for (i = 0; i < len; i += 1) {
+            for (var i = 0; i < len; i += 1) {
                 expressionValue[i] = arrValue[i] = property.v[i] * mult;
             }
             return expressionValue;


### PR DESCRIPTION
undefined 'i' in 'for loop' in function returned by MultidimensionalPropertyInterface. 
Causing 'i is undefined' error