### PR TITLE
Lock event-stream to 3.3.4 to avoid malware injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "export"
   ],
   "devDependencies": {
-    "event-stream": "^3.3.4",
+    "event-stream": "3.3.4",
     "events-stream": "^0.2.0",
     "gulp": "^3.9.1",
     "gulp-batch-replace": "0.0.0",


### PR DESCRIPTION
`event-stream` should be locked to 3.3.4. Since the carat (`^3.3.4`) is used currently, it can pull in later versions which could be vulnerable to the attack mentioned in https://github.com/dominictarr/event-stream/issues/116. It seems like it's just a `devDependency` for `lottie-web` though, so I don't think it would be able to do too much harm. There's a good summary of what this attack could do in [this comment](https://github.com/dominictarr/event-stream/issues/116#issuecomment-441749105).