### PR TITLE
Add TypeScript type definitions

### DIFF
--- a/build/player/lottie.d.ts
+++ b/build/player/lottie.d.ts
@@ -1,0 +1,5 @@
+import { default as Lottie } from '../../index';
+
+export * from '../../index';
+
+export default Lottie;

--- a/build/player/lottie_html.d.ts
+++ b/build/player/lottie_html.d.ts
@@ -1,0 +1,5 @@
+import { default as Lottie } from '../../index';
+
+export * from '../../index';
+
+export default Lottie;

--- a/build/player/lottie_light.d.ts
+++ b/build/player/lottie_light.d.ts
@@ -1,0 +1,5 @@
+import { default as Lottie } from '../../index';
+
+export * from '../../index';
+
+export default Lottie;

--- a/build/player/lottie_light_canvas.d.ts
+++ b/build/player/lottie_light_canvas.d.ts
@@ -1,0 +1,5 @@
+import { default as Lottie } from '../../index';
+
+export * from '../../index';
+
+export default Lottie;

--- a/build/player/lottie_light_html.d.ts
+++ b/build/player/lottie_light_html.d.ts
@@ -1,0 +1,5 @@
+import { default as Lottie } from '../../index';
+
+export * from '../../index';
+
+export default Lottie;

--- a/build/player/lottie_svg.d.ts
+++ b/build/player/lottie_svg.d.ts
@@ -1,0 +1,5 @@
+import { default as Lottie } from '../../index';
+
+export * from '../../index';
+
+export default Lottie;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,81 @@
+export type AnimationDirection = 1 | -1;
+export type AnimationSegment = [number, number];
+export type AnimationEventName = 'enterFrame' | 'loopComplete' | 'complete' | 'segmentStart' | 'destroy';
+export type AnimationEventCallback<T = any> = (args: T) => void;
+
+export type AnimationItem = {
+    play();
+    stop();
+    pause();
+    setLocationHref(href: string);
+    setSpeed(speed: number);
+    goToAndPlay(value: number, isFrame?: boolean);
+    goToAndStop(value: number, isFrame?: boolean);
+    setDirection(direction: AnimationDirection);
+    playSegments(segments: AnimationSegment | AnimationSegment[], forceFlag?: boolean);
+    setSubframe(useSubFrames: boolean);
+    destroy();
+    getDuration(inFrames?: boolean): number;
+    triggerEvent<T = any>(name: AnimationEventName, args: T);
+    addEventListener<T = any>(name: AnimationEventName, callback: AnimationEventCallback<T>);
+    removeEventListener<T = any>(name: AnimationEventName, callback: AnimationEventCallback<T>);
+}
+
+export type BaseRendererConfig = {
+    imagePreserveAspectRatio?: string;
+    className?: string;
+};
+
+export type SVGRendererConfig = BaseRendererConfig & {
+    title?: string;
+    description?: string;
+    preserveAspectRatio?: string;
+    progressiveLoad?: boolean;
+    hideOnTransparent?: boolean;
+    viewBoxOnly?: boolean;
+    viewBoxSize?: string;
+};
+
+export type CanavasRendererConfig = BaseRendererConfig & {
+    clearCanvas?: boolean;
+    context?: CanvasRenderingContext2D;
+    progressiveLoad?: boolean;
+    preserveAspectRatio?: string;
+};
+
+export type HTMLRendererConfig = BaseRendererConfig & {
+    hideOnTransparent?: boolean;
+};
+
+export type AnimationConfig = {
+    container: HTMLElement;
+    renderer?: 'svg' | 'canvas' | 'html';
+    loop?: boolean | number;
+    autoplay?: boolean;
+    name?: string;
+    rendererSettings?: SVGRendererConfig | CanavasRendererConfig | HTMLRendererConfig;
+}
+
+export type AnimationConfigWithPath = AnimationConfig & {
+    path?: string;
+}
+
+export type AnimationConfigWithData = AnimationConfig & {
+    animationData?: any;
+}
+
+type LottiePlayer = {
+    play(name?: string);
+    stop(name?: string);
+    setSpeed(speed: number, name?: string);
+    setDirection(direction: AnimationDirection, name?: string);
+    searchAnimations(animationData?: any, standalone?: boolean, renderer?: string);
+    loadAnimation(params: AnimationConfigWithPath | AnimationConfigWithData): AnimationItem;
+    destroy(name?: string);
+    registerAnimation(element: HTMLElement, animationData?: any);
+    setQuality(quality: string | number);
+}
+
+const Lottie: LottiePlayer;
+
+export default Lottie;

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,7 +48,7 @@ export type HTMLRendererConfig = BaseRendererConfig & {
 };
 
 export type AnimationConfig = {
-    container: HTMLElement;
+    container: Element;
     renderer?: 'svg' | 'canvas' | 'html';
     loop?: boolean | number;
     autoplay?: boolean;
@@ -72,7 +72,7 @@ type LottiePlayer = {
     searchAnimations(animationData?: any, standalone?: boolean, renderer?: string);
     loadAnimation(params: AnimationConfigWithPath | AnimationConfigWithData): AnimationItem;
     destroy(name?: string);
-    registerAnimation(element: HTMLElement, animationData?: any);
+    registerAnimation(element: Element, animationData?: any);
     setQuality(quality: string | number);
 }
 

--- a/package.json
+++ b/package.json
@@ -22,5 +22,6 @@
     "cheerio": "^1.0.0-rc.2",
     "uglify-js": "^3.4.9"
   },
+  "types": "./index.d.ts",
   "license": "MIT"
 }


### PR DESCRIPTION
Related to: https://github.com/airbnb/lottie-web/issues/862

It would be great to have the possibility to use this library in TypeScript since more and more people are moving towards typed languages and TypeScript seems to take the lead in this category. I suggest to add type definitions inside the `lottie-web` repo instead of `DefinitlyTyped` because having to separate repos can lead to out of sync typings and also PRs on `DefinitlyTyped` take a huge time to be accepted.

I wrote the definitions according to the previous work of @agentschmitt and also by inspecting the source code a bit to find what options were available.

Thanks