### PR TITLE
Fix loader issue on pre-kitkat Android webview

### DIFF
--- a/player/js/utils/asset_loader.js
+++ b/player/js/utils/asset_loader.js
@@ -15,7 +15,10 @@ var assetLoader = (function(){
 		var xhr = new XMLHttpRequest();
 		xhr.open('GET', path, true);
 		// set responseType after calling open or IE will break.
-		xhr.responseType = "json";
+		try {
+		    // This crashes on Android WebView prior to KitKat
+		    xhr.responseType = "json";
+		} catch (err) {}
 	    xhr.send();
 	    xhr.onreadystatechange = function () {
 	        if (xhr.readyState == 4) {


### PR DESCRIPTION
When lottie-web is used inside a Cordova Android app it would fail to load the JSONs if the version was under 4.4.

This PR fixes the issue.