### PR TITLE
Fix masksProperties key name in JSON docs.

### DIFF
--- a/docs/json/layers/image.json
+++ b/docs/json/layers/image.json
@@ -88,11 +88,11 @@
     },
     "hasMask": {
       "title": "Has Masks",
-      "description": "Boolean when layer has a mask. Will be deprecated in favor of checking maskProperties.",
+      "description": "Boolean when layer has a mask. Will be deprecated in favor of checking masksProperties.",
       "type": "number"
     },
-    "maskProperties": {
-      "title": "Mask Properties",
+    "masksProperties": {
+      "title": "Masks Properties",
       "description": "List of Masks",
       "items": {
         "oneOf": [

--- a/docs/json/layers/preComp.json
+++ b/docs/json/layers/preComp.json
@@ -87,11 +87,11 @@
     },
     "hasMask": {
       "title": "Has Masks",
-      "description": "Boolean when layer has a mask. Will be deprecated in favor of checking maskProperties.",
+      "description": "Boolean when layer has a mask. Will be deprecated in favor of checking masksProperties.",
       "type": "number"
     },
-    "maskProperties": {
-      "title": "Mask Properties",
+    "masksProperties": {
+      "title": "Masks Properties",
       "description": "List of Masks",
       "items": {
         "oneOf": [

--- a/docs/json/layers/shape.json
+++ b/docs/json/layers/shape.json
@@ -88,11 +88,11 @@
     },
     "hasMask": {
       "title": "Has Masks",
-      "description": "Boolean when layer has a mask. Will be deprecated in favor of checking maskProperties.",
+      "description": "Boolean when layer has a mask. Will be deprecated in favor of checking masksProperties.",
       "type": "number"
     },
-    "maskProperties": {
-      "title": "Mask Properties",
+    "masksProperties": {
+      "title": "Masks Properties",
       "description": "List of Masks",
       "items": {
         "oneOf": [

--- a/docs/json/layers/solid.json
+++ b/docs/json/layers/solid.json
@@ -88,11 +88,11 @@
     },
     "hasMask": {
       "title": "Has Masks",
-      "description": "Boolean when layer has a mask. Will be deprecated in favor of checking maskProperties.",
+      "description": "Boolean when layer has a mask. Will be deprecated in favor of checking masksProperties.",
       "type": "number"
     },
-    "maskProperties": {
-      "title": "Mask Properties",
+    "masksProperties": {
+      "title": "Masks Properties",
       "description": "List of Masks",
       "items": {
         "oneOf": [

--- a/docs/json/layers/text.json
+++ b/docs/json/layers/text.json
@@ -88,11 +88,11 @@
     },
     "hasMask": {
       "title": "Has Masks",
-      "description": "Boolean when layer has a mask. Will be deprecated in favor of checking maskProperties.",
+      "description": "Boolean when layer has a mask. Will be deprecated in favor of checking masksProperties.",
       "type": "number"
     },
-    "maskProperties": {
-      "title": "Mask Properties",
+    "masksProperties": {
+      "title": "Masks Properties",
       "description": "List of Masks",
       "items": {
         "oneOf": [


### PR DESCRIPTION
It looks like all the code (and examples on the web) have `masksProperties` in JSON, not `maskProperties`.