### PR TITLE
Fix mask points definition in docs.

### DIFF
--- a/docs/json/helpers/mask.json
+++ b/docs/json/helpers/mask.json
@@ -16,18 +16,15 @@
     "pt": {
       "title": "Points",
       "description": "Mask vertices",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "oneOf": [
-          {
-            "$ref": "#/properties/shape"
-          },
-          {
-            "$ref": "#/properties/shapeKeyframed"
-          }
-        ]
-      }
+      "oneOf": [
+        {
+          "$ref": "#/properties/shape"
+        },
+        {
+          "$ref": "#/properties/shapeKeyframed"
+        }
+      ],
+      "type": "object"
     },
     "o": {
       "title": "Opacity",


### PR DESCRIPTION
Judging by the player code:

https://github.com/airbnb/lottie-web/blob/master/player/js/utils/DataManager.js

the `pt` field in a `masksProperties` element is parsed the same way as `ks` in a `shape` - like an object (`properties/shape` or `properties/shapeKeyframed`), not like an array of such objects.