### PR TITLE
Replace scaleMode with preserveAspectRatio in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ lottie.loadAnimation({
   animationData: animationData, // the animation data
   rendererSettings: {
     context: canvasContext, // the canvas context
-    scaleMode: 'noScale',
+    preserveAspectRatio: 'xMinYMin slice', // Supports the same options as the svg element's preserveAspectRatio property
     clearCanvas: false,
     progressiveLoad: false, // Boolean, only svg renderer, loads dom elements when needed. Might speed up initialization for large number of elements.
     hideOnTransparent: true, //Boolean, only svg renderer, hides elements when opacity reaches 0 (defaults to true)


### PR DESCRIPTION
scaleMode appears to be deprecated (didn't do anything and is missing in the TypeScript types).

https://stackoverflow.com/questions/53938016/lottie-and-scalemode-settings-for-the-web says preserveAspectRatio replaced it, and this change updates the docs to use that instead.