### PR TITLE
fix: incorrect easing function calculation in TextSelectorProperty

### DIFF
--- a/player/js/utils/text/TextSelectorProperty.js
+++ b/player/js/utils/text/TextSelectorProperty.js
@@ -33,7 +33,24 @@ var TextSelectorProp = (function(){
                 this.getValue();
             }
             //var easer = bez.getEasingCurve(this.ne.v/100,0,1-this.xe.v/100,1);
-            var easer = BezierFactory.getBezierEasing(this.ne.v/100,0,1-this.xe.v/100,1).get;
+            var x1 = 0;
+            var y1 = 0;
+            var x2 = 1;
+            var y2 = 1;
+            if(this.ne.v > 0) {
+                x1 = this.ne.v / 100.0;
+            }
+            else {
+                y1 = -this.ne.v / 100.0;
+            }
+            if(this.xe.v > 0) {
+                x2 = 1.0 - this.xe.v / 100.0;
+            }
+            else {
+                y2 = 1.0 + this.xe.v / 100.0;
+            }
+            var easer = BezierFactory.getBezierEasing(x1, y1, x2, y2).get;
+
             var mult = 0;
             var s = this.finalS;
             var e = this.finalE;


### PR DESCRIPTION
The parameter of easing function calculate from ease low and ease high is incorrect if each of them  is negative. I have created a simple project to prove this. The yellow texts layer is created with a selector property and both ease low and ease high are set to -100. The red texts are just used for referencing.
[proveEasingFunction.aep.zip](https://github.com/airbnb/lottie-web/files/3727855/proveEasingFunction.aep.zip)

![prove](https://user-images.githubusercontent.com/43688968/66809486-04ec3a80-ef60-11e9-9d56-99d5065e52e2.png)

