### PR TITLE
Fallback expressions to their original value if they have any errors

### DIFF
--- a/player/js/utils/PropertyFactory.js
+++ b/player/js/utils/PropertyFactory.js
@@ -282,7 +282,7 @@ var PropertyFactory = (function(){
         var i, len = this.effectsSequence.length;
         var finalValue = this.kf ? this.pv : this.data.k;
         for(i = 0; i < len; i += 1) {
-            finalValue = this.effectsSequence[i](finalValue);
+            finalValue = this.effectsSequence[i](finalValue) || finalValue;
         }
         this.setVValue(finalValue);
         this._isFirstFrame = false;

--- a/player/js/utils/expressions/ExpressionManager.js
+++ b/player/js/utils/expressions/ExpressionManager.js
@@ -647,7 +647,13 @@ var ExpressionManager = (function(){
             if (needsVelocity) {
                 velocity = velocityAtTime(time);
             }
-            expression_function();
+
+            try {
+              expression_function();
+            } catch(e) {
+              return null;
+            }
+
             this.frameExpressionId = elem.globalData.frameId;
 
 

--- a/player/js/utils/shapes/ShapeProperty.js
+++ b/player/js/utils/shapes/ShapeProperty.js
@@ -133,7 +133,7 @@ var ShapePropertyFactory = (function(){
         var finalValue = this.kf ? this.pv : this.data.ks ? this.data.ks.k : this.data.pt.k;
         var i, len = this.effectsSequence.length;
         for(i = 0; i < len; i += 1) {
-            finalValue = this.effectsSequence[i](finalValue);
+            finalValue = this.effectsSequence[i](finalValue) || finalValue;
         }
         this.setVValue(finalValue);
         this.lock = false;


### PR DESCRIPTION
Hi!

I am using and enjoying Lottie a lot, this is a great project you people maintain!

I've had some problems with one of my Lottie files though, it had an expression that references a layer that does not exist. I've prepared a jsfiddle to demonstrate it here: https://jsfiddle.net/nihey/xtgnfqz3/ (the animationData is contained in the example).

The problem is caused by a layer that is hidden and not exported into the JSON, causing one of the expressions to be exported as: `var $bm_rt;\n$bm_rt = thisComp.layer('Color Control').effect('Shape 2 Color')('ADBE Color Control-0001')`. 

If you check this part of the code and uncomment the `goToAndPlay`, the animation runs perfectly.
It seems these expression problems are only caused when I try to `goToAndStop` into the animation.

```javascript
animation.addEventListener('loaded_images', () => {
  animation.goToAndStop(300, true);
  // animation.goToAndPlay(300, true);
})
```

I've made this change on the library that enable us to seek even with expressions with problems, it fallbacks their value to the one set on the original field.

What do you think about this change? Do you think it could be merged on the main repository? It solved our problem on the animations we are doing.

Let me know if I need to clarify the issues we faced even further