### PR TITLE
Add missing isLoaded property in type definitions.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ export type AnimationEventCallback<T = any> = (args: T) => void;
 export type AnimationItem = {
 
     name: string;
+    isLoaded: boolean;
     currentFrame: number;
     currentRawFrame: number;
     firstFrame: number;


### PR DESCRIPTION
# Description
This adds the missing `isLoaded` property to `AnimationItem` in type definition file.