### PR TITLE
Add filterSize declaration to AnimationConfig

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,6 +63,7 @@ export type SVGRendererConfig = BaseRendererConfig & {
     viewBoxOnly?: boolean;
     viewBoxSize?: string;
     focusable?: boolean;
+    filterSize?: FilterSizeConfig;
 };
 
 export type CanvasRendererConfig = BaseRendererConfig & {
@@ -93,6 +94,13 @@ export type AnimationConfigWithPath = AnimationConfig & {
 export type AnimationConfigWithData = AnimationConfig & {
     animationData?: any;
 }
+
+export type FilterSizeConfig = {
+    width: string;
+    height: string;
+    x: string;
+    y: string;
+};
 
 type LottiePlayer = {
     play(name?: string): void;


### PR DESCRIPTION
This declaration was missing even though `filterSize` is a valid property and used throughout the library.

Should resolve https://github.com/airbnb/lottie-web/issues/2179.