### PR TITLE
Add missing initialSegment property in type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,6 @@ export type AnimationEventName = 'enterFrame' | 'loopComplete' | 'complete' | '
 export type AnimationEventCallback<T = any> = (args: T) => void;
 
 export type AnimationItem = {
-
     name: string;
     isLoaded: boolean;
     currentFrame: number;
@@ -81,6 +80,7 @@ export type AnimationConfig = {
     renderer?: 'svg' | 'canvas' | 'html';
     loop?: boolean | number;
     autoplay?: boolean;
+    initialSegment?: AnimationSegment;        
     name?: string;
     assetsPath?: string;
     rendererSettings?: SVGRendererConfig | CanvasRendererConfig | HTMLRendererConfig;


### PR DESCRIPTION
`initialSegment` property was missing from the `AnimationItem` type. I've added it as optional key with the type of `AnimationSegment`.