### PR TITLE
fix: type id was missing on rendererSettings type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,6 +51,7 @@ export type AnimationItem = {
 export type BaseRendererConfig = {
     imagePreserveAspectRatio?: string;
     className?: string;
+    id?: string;
 };
 
 export type SVGRendererConfig = BaseRendererConfig & {


### PR DESCRIPTION
Hello, adding a missing type `id` on `rendererSettings` type .