### PR TITLE
Check if effectsManager exists before adding new SVGEffects

### DIFF
--- a/player/js/elements/svgElements/SVGBaseElement.js
+++ b/player/js/elements/svgElements/SVGBaseElement.js
@@ -118,7 +118,7 @@ SVGBaseElement.prototype = {
             } else {
                 this.layerElement.setAttribute('clip-path','url(' + locationHref + '#'+clipId+')');
             }
-            
+
         }
         if (this.data.bm !== 0) {
             this.setBlendMode();
@@ -146,6 +146,7 @@ SVGBaseElement.prototype = {
     },
     createRenderableComponents: function() {
         this.maskManager = new MaskElement(this.data, this, this.globalData);
+        if (Object.keys(this.effectsManager).length === 0) return;
         this.renderableEffectsManager = new SVGEffects(this);
     },
     setMatte: function(id) {


### PR DESCRIPTION
This pull request fixes an error on Lottie light when using `SVGEffects` by checking if the `effectsManager` exists.

**How did we get here**

When using Lottie we encountered a CSP issue when loading animations. This happend because Lottie uses `eval()` to render certain effects. The easy fix then was to make the switch to Lottie light.

Once this CSP issue was resolved, we got a new error when the animation was destroyed:

```
this.elements[i].destroy() is not a function
```

The error occured because the elements array was not properly constructed and some items just contained the value `true` and `(true).destroy()` triggers the error above.

When looking for the reason why the element contained `true` we noticed that `new SVGEffects()` uses the EffectManager. This function still exists in Lottie light, but is empty. Lottie crashed on this and catches the error so it is not shown immediately. The browser error happens when destroying and not in the initial loading of the animation.

By preventing that we add any effects in Lottie light, the animation is loaded in the same way as before, but doesn't crash when destroying.