### PR TITLE
Cater for null callbacks array after destroy

### DIFF
--- a/player/js/utils/BaseEvent.js
+++ b/player/js/utils/BaseEvent.js
@@ -1,7 +1,7 @@
 function BaseEvent(){}
 BaseEvent.prototype = {
 	triggerEvent: function (eventName, args) {
-	    if (this._cbs[eventName]) {
+	    if (this._cbs && this._cbs[eventName]) {
 	        var len = this._cbs[eventName].length;
 	        for (var i = 0; i < len; i++){
 	            this._cbs[eventName][i](args);
@@ -9,6 +9,9 @@ BaseEvent.prototype = {
 	    }
 	},
 	addEventListener: function (eventName, callback) {
+	    if (!this._cbs) {
+	      return;
+	    }
 	    if (!this._cbs[eventName]){
 	        this._cbs[eventName] = [];
 	    }
@@ -19,6 +22,9 @@ BaseEvent.prototype = {
 		}.bind(this);
 	},
 	removeEventListener: function (eventName,callback){
+	    if (!this._cbs) {
+	      return;
+	    }
 	    if (!callback){
 	        this._cbs[eventName] = null;
 	    }else if(this._cbs[eventName]){


### PR DESCRIPTION
After the destroy method has been called on `AnimationItem` the `_cbs`
array of event listeners is replaced with `null` which means that
subsequent calls to add, trigger or remove event listeners which tried
to access a particular name on that object resulted in "TypeError:
this._cbs is null". Checking that the `_cbs` array is truthy makes the
`addEventListener`, `triggerEvent`, and `removeEventListener` methods
safe to call in the same way as `AnimationItem.trigger` is even after
the animation has been destroyed.