### PR TITLE
Fixed typo in 'ef' description

### DIFF
--- a/docs/json/effects/proLevels.json
+++ b/docs/json/effects/proLevels.json
@@ -25,7 +25,7 @@
     },
     "ef": {
       "title": "Effects",
-      "description": "ffect List of properties.",
+      "description": "Effect List of properties.",
       "type": "array",
       "items": [
         {


### PR DESCRIPTION
The 'E' in the 'ef' description was missing.