### PR TITLE
Enable HImageElement to use preloaded images

### DIFF
--- a/player/js/elements/htmlElements/HImageElement.js
+++ b/player/js/elements/htmlElements/HImageElement.js
@@ -21,6 +21,7 @@ HImageElement.prototype.createContent = function(){
     } else {
         this.layerElement.appendChild(img);
     }
+    img.crossOrigin = 'anonymous';
     img.src = assetPath;
     if(this.data.ln){
         this.baseElement.setAttribute('id',this.data.ln);


### PR DESCRIPTION
The preloader previously used crossorigin='anonymous' when creating images (#1045), while HImageElement did not. This resulted in those two requests recognized as different by the browser, since one is a CORS request while the other is not. In other words, the preloaded image was not used at all when creating DOM image elements.

**NOTE**: If someone used preloading in their own app to go around this problem, by preloading without crossorigin='anonymous', merging of this PR will (in Chrome) result in their images not loading because of [this issue](https://bugs.chromium.org/p/chromium/issues/detail?id=409090). The only thing they need to do then is either remove their preloading (since this should fix it) or, if they have different reasons for preloading before initializing the lottie animation, just add crossorigin='anonymous' - this might be a reason to merge this as a breaking change.