### PR TITLE
Fix character width calculations

### DIFF
--- a/player/js/utils/FontManager.js
+++ b/player/js/utils/FontManager.js
@@ -94,9 +94,11 @@ var FontManager = (function(){
         var tHelper = createNS('text');
         tHelper.style.fontSize = '100px';
         //tHelper.style.fontFamily = fontData.fFamily;
+
+        var fontProps = getFontProperties(fontData);
         tHelper.setAttribute('font-family', fontData.fFamily);
-        tHelper.setAttribute('font-style', fontData.fStyle);
-        tHelper.setAttribute('font-weight', fontData.fWeight);
+        tHelper.setAttribute('font-style', fontProps.style);
+        tHelper.setAttribute('font-weight', fontProps.weight);
         tHelper.textContent = '1';
         if(fontData.fClass){
             tHelper.style.fontFamily = 'inherit';

--- a/player/js/utils/getFontProperties.js
+++ b/player/js/utils/getFontProperties.js
@@ -1,0 +1,37 @@
+function getFontProperties(fontData) {
+	var styles = fontData.fStyle ? fontData.fStyle.split(' ') : [];
+
+	var fWeight = 'normal', fStyle = 'normal';
+	var len = styles.length;
+	var styleName;
+	for (var i = 0; i < len; i += 1) {
+		styleName = styles[i].toLowerCase();
+		switch (styleName) {
+			case 'italic':
+				fStyle = 'italic';
+				break;
+			case 'bold':
+				fWeight = '700';
+				break;
+			case 'black':
+				fWeight = '900';
+				break;
+			case 'medium':
+				fWeight = '500';
+				break;
+			case 'regular':
+			case 'normal':
+				fWeight = '400';
+				break;
+			case 'light':
+			case 'thin':
+				fWeight = '200';
+				break;
+		}
+	}
+
+	return {
+		style: fStyle,
+		weight: fontData.fWeight || fWeight
+	};
+}

--- a/player/js/utils/text/TextProperty.js
+++ b/player/js/utils/text/TextProperty.js
@@ -177,38 +177,10 @@ TextProperty.prototype.completeTextData = function(documentData) {
     var j, jLen;
     var fontData = fontManager.getFontByName(documentData.f);
     var charData, cLength = 0;
-    var styles = fontData.fStyle ? fontData.fStyle.split(' ') : [];
 
-    var fWeight = 'normal', fStyle = 'normal';
-    len = styles.length;
-    var styleName;
-    for(i=0;i<len;i+=1){
-        styleName = styles[i].toLowerCase();
-        switch(styleName) {
-            case 'italic':
-            fStyle = 'italic';
-            break;
-            case 'bold':
-            fWeight = '700';
-            break;
-            case 'black':
-            fWeight = '900';
-            break;
-            case 'medium':
-            fWeight = '500';
-            break;
-            case 'regular':
-            case 'normal':
-            fWeight = '400';
-            break;
-            case 'light':
-            case 'thin':
-            fWeight = '200';
-            break;
-        }
-    }
-    documentData.fWeight = fontData.fWeight || fWeight;
-    documentData.fStyle = fStyle;
+    var fontProps = getFontProperties(fontData);
+    documentData.fWeight = fontProps.weight;
+    documentData.fStyle = fontProps.style;
     documentData.finalSize = documentData.s;
     documentData.finalText = this.buildFinalText(documentData.t);
     len = documentData.finalText.length;

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -73,6 +73,10 @@ const scripts = [
 		builds: ['canvas_worker']
 	},
 	{
+		src: 'js/utils/getFontProperties.js',
+		builds: defaultBuilds
+	},
+	{
 		src: 'js/utils/FontManager.js',
 		builds: defaultBuilds
 	},


### PR DESCRIPTION
When a font weight & style different than normal is used, Lottie was calculating the character widths wrong, and therefore it seemed like the text had wrong kerning. 

With fix:
![image](https://user-images.githubusercontent.com/2637884/101812468-63bc2e00-3ae9-11eb-8da1-0e9708effb62.png)

Without fix:
![image](https://user-images.githubusercontent.com/2637884/101812601-8ea68200-3ae9-11eb-8f32-d64ab659242e.png)

I have not included the build files, let me know if I should.

This PR probably fixes some issues, I will keep adding to this list as I find them: #1864, #1839 

Thanks!