### PR TITLE
Recalculate text selector range if characters have changed

### DIFF
--- a/player/js/utils/text/TextSelectorProperty.js
+++ b/player/js/utils/text/TextSelectorProperty.js
@@ -32,6 +32,9 @@ var TextSelectorProp = (function(){
             if(this._currentTextLength !== this.elem.textProperty.currentData.l.length) {
                 this.getValue();
             }
+            if (this._currentTotalChars !== this.data.totalChars) {
+                this.getValue();
+            }
             //var easer = bez.getEasingCurve(this.ne.v/100,0,1-this.xe.v/100,1);
             var x1 = 0;
             var y1 = 0;
@@ -123,6 +126,8 @@ var TextSelectorProp = (function(){
                 this.e.v = this._currentTextLength;
             }
             var divisor = this.data.r === 2 ? 1 : 100 / this.data.totalChars;
+            this._currentTotalChars = this.data.totalChars;
+
             var o = this.o.v/divisor;
             var s = this.s.v/divisor + o;
             var e = (this.e.v/divisor) + o;


### PR DESCRIPTION
In a certain case, the text selector range was being wrongly calculated. This PR fixes that, by recalculating selector range more often (if total characters have changed.)

Example:

Before fix:
![image](https://user-images.githubusercontent.com/2637884/101953777-faabe780-3bc8-11eb-9aad-00a6d3976b41.png)

After fix:
![image](https://user-images.githubusercontent.com/2637884/101953783-ff709b80-3bc8-11eb-8a95-87f8a7bc0cc3.png)

One peculiar thing I noted about when this happens (might not be true though), is that these layers had a newline character in them. 

Thanks!