### PR TITLE
Recalculate text selector range if characters have changed, another fix

### DIFF
--- a/player/js/elements/TextElement.js
+++ b/player/js/elements/TextElement.js
@@ -42,14 +42,17 @@ ITextElement.prototype.createPathShape = function(matrixHelper, shapes) {
 
 ITextElement.prototype.updateDocumentData = function(newData, index) {
     this.textProperty.updateDocumentData(newData, index);
+    this.textAnimator.searchProperties();
 };
 
 ITextElement.prototype.canResizeFont = function(_canResize) {
     this.textProperty.canResizeFont(_canResize);
+    this.textAnimator.searchProperties();
 };
 
 ITextElement.prototype.setMinimumFontSize = function(_fontSize) {
     this.textProperty.setMinimumFontSize(_fontSize);
+    this.textAnimator.searchProperties();
 };
 
 ITextElement.prototype.applyTextPropertiesToMatrix = function(documentData, matrixHelper, lineNumber, xPos, yPos) {


### PR DESCRIPTION
Hi!

I made another fix for #2393 

This one works by forcing TextAnimator to re-create `TextAnimatorDataProperty ` when canResizeFont is changed

I think this is a much more elegant solution than #2393 , but I will leave up to you to decide which fix is better. 

Example:

Before fix:
![image](https://user-images.githubusercontent.com/2637884/101953777-faabe780-3bc8-11eb-9aad-00a6d3976b41.png)

After fix:
![image](https://user-images.githubusercontent.com/2637884/101953783-ff709b80-3bc8-11eb-8a95-87f8a7bc0cc3.png)

The AEP file & Lottie JSON that demonstrates the issue can be found here: https://drive.google.com/drive/folders/1cbWqJuuyUkt_C8GlIguZH2pi9lHj7Lok?usp=sharing 

Thanks!