### PR TITLE
Canvas worker fix

### DIFF
--- a/player/js/module_worker.js
+++ b/player/js/module_worker.js
@@ -1,4 +1,4 @@
-var lottiejs = (function(window) {
+var lottie = (function(window) {
     "use strict";
     /*<%= contents %>*/
     var lottiejs = {};
@@ -46,9 +46,9 @@ var lottiejs = (function(window) {
     lottiejs.setQuality = setQuality;
     lottiejs.freeze = animationManager.freeze;
     lottiejs.unfreeze = animationManager.unfreeze;
-    lottie.setVolume = animationManager.setVolume;
-    lottie.mute = animationManager.mute;
-    lottie.unmute = animationManager.unmute;
+    lottiejs.setVolume = animationManager.setVolume;
+    lottiejs.mute = animationManager.mute;
+    lottiejs.unmute = animationManager.unmute;
     lottiejs.getRegisteredAnimations = animationManager.getRegisteredAnimations;
     lottiejs.version = '[[BM_VERSION]]';
 
@@ -62,7 +62,7 @@ var onmessage = function(evt) {
     var canvas = evt.data.canvas;
     var params = evt.data.params;
     var ctx = canvas.getContext("2d");
-    var animation = lottiejs.loadAnimation({
+    var animation = lottie.loadAnimation({
         renderer: 'canvas',
         loop: evt.data.loop,
         autoplay: true,

--- a/player/js/module_worker.js
+++ b/player/js/module_worker.js
@@ -58,7 +58,7 @@ var lottie = (function(window) {
 
 var animations = [];
 
-var onmessage = function(evt) {
+onmessage = function(evt) {
     var canvas = evt.data.canvas;
     var params = evt.data.params;
     var ctx = canvas.getContext("2d");

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -676,7 +676,8 @@ function uglifyCode(code) {
 	})
 }
 
-async function modularizeCode(code) {
+async function modularizeCode(code, build) {
+	const globalScope = (build =='canvas_worker') ? 'self' : 'window'
 	return `(typeof navigator !== "undefined") && (function(root, factory) {
     if (typeof define === "function" && define.amd) {
         define(function() {
@@ -688,7 +689,7 @@ async function modularizeCode(code) {
         root.lottie = factory(root);
         root.bodymovin = root.lottie;
     }
-}((window || {}), function(window) {
+}((${globalScope} || {}), function(window) {
 	${code}
 return lottie;
 }));`
@@ -698,7 +699,7 @@ async function buildVersion(scripts, version) {
 	const code = await concatScripts(scripts, version.build)
 	const wrappedCode = await wrapScriptWithModule(code, version.build)
 	const processedCode = await version.process(wrappedCode)
-	const modularizedCode = await modularizeCode(processedCode)
+	const modularizedCode = await modularizeCode(processedCode, version.build)
 	const saved = await save(modularizedCode, version.fileName)
 	return true
 }


### PR DESCRIPTION
Fix for #2414
- Removing wrong encapsulation: `window` to `self`
- `var onmessage` to `onmessage`