### PR TITLE
Fix Rollup treeshaking

### DIFF
--- a/build/player/lottie.js
+++ b/build/player/lottie.js
@@ -13581,7 +13581,7 @@ var ExpressionManager = (function () {
 
     var active = !this.data || this.data.hd !== true;
 
-    var wiggle = function wiggle(freq, amp) {
+    function wiggle(freq, amp) {
       var iWiggle;
       var j;
       var lenWiggle = this.pv.length ? this.pv.length : 1;
@@ -13611,7 +13611,8 @@ var ExpressionManager = (function () {
         return arr;
       }
       return this.pv + addedAmps[0] + (-amp + amp * 2 * BMMath.random()) * perc;
-    }.bind(this);
+    }
+    wiggle.bind(this);
 
     if (thisProperty.loopIn) {
       loopIn = thisProperty.loopIn.bind(thisProperty);

--- a/build/player/lottie_canvas.js
+++ b/build/player/lottie_canvas.js
@@ -11191,7 +11191,7 @@ var ExpressionManager = (function () {
 
     var active = !this.data || this.data.hd !== true;
 
-    var wiggle = function wiggle(freq, amp) {
+    function wiggle(freq, amp) {
       var iWiggle;
       var j;
       var lenWiggle = this.pv.length ? this.pv.length : 1;
@@ -11221,7 +11221,8 @@ var ExpressionManager = (function () {
         return arr;
       }
       return this.pv + addedAmps[0] + (-amp + amp * 2 * BMMath.random()) * perc;
-    }.bind(this);
+    }
+    wiggle.bind(this);
 
     if (thisProperty.loopIn) {
       loopIn = thisProperty.loopIn.bind(thisProperty);

--- a/build/player/lottie_canvas_worker.js
+++ b/build/player/lottie_canvas_worker.js
@@ -11192,7 +11192,7 @@ var ExpressionManager = (function () {
 
     var active = !this.data || this.data.hd !== true;
 
-    var wiggle = function wiggle(freq, amp) {
+    function wiggle(freq, amp) {
       var iWiggle;
       var j;
       var lenWiggle = this.pv.length ? this.pv.length : 1;
@@ -11222,7 +11222,8 @@ var ExpressionManager = (function () {
         return arr;
       }
       return this.pv + addedAmps[0] + (-amp + amp * 2 * BMMath.random()) * perc;
-    }.bind(this);
+    }
+    wiggle.bind(this);
 
     if (thisProperty.loopIn) {
       loopIn = thisProperty.loopIn.bind(thisProperty);

--- a/build/player/lottie_html.js
+++ b/build/player/lottie_html.js
@@ -12229,7 +12229,7 @@ var ExpressionManager = (function () {
 
     var active = !this.data || this.data.hd !== true;
 
-    var wiggle = function wiggle(freq, amp) {
+    function wiggle(freq, amp) {
       var iWiggle;
       var j;
       var lenWiggle = this.pv.length ? this.pv.length : 1;
@@ -12259,7 +12259,8 @@ var ExpressionManager = (function () {
         return arr;
       }
       return this.pv + addedAmps[0] + (-amp + amp * 2 * BMMath.random()) * perc;
-    }.bind(this);
+    }
+    wiggle.bind(this);
 
     if (thisProperty.loopIn) {
       loopIn = thisProperty.loopIn.bind(thisProperty);

--- a/build/player/lottie_svg.js
+++ b/build/player/lottie_svg.js
@@ -11059,7 +11059,7 @@ var ExpressionManager = (function () {
 
     var active = !this.data || this.data.hd !== true;
 
-    var wiggle = function wiggle(freq, amp) {
+    function wiggle(freq, amp) {
       var iWiggle;
       var j;
       var lenWiggle = this.pv.length ? this.pv.length : 1;
@@ -11089,7 +11089,8 @@ var ExpressionManager = (function () {
         return arr;
       }
       return this.pv + addedAmps[0] + (-amp + amp * 2 * BMMath.random()) * perc;
-    }.bind(this);
+    }
+    wiggle.bind(this);
 
     if (thisProperty.loopIn) {
       loopIn = thisProperty.loopIn.bind(thisProperty);

--- a/player/js/utils/expressions/ExpressionManager.js
+++ b/player/js/utils/expressions/ExpressionManager.js
@@ -415,7 +415,7 @@ var ExpressionManager = (function () {
 
     var active = !this.data || this.data.hd !== true;
 
-    var wiggle = function wiggle(freq, amp) {
+    function wiggle(freq, amp) {
       var iWiggle;
       var j;
       var lenWiggle = this.pv.length ? this.pv.length : 1;
@@ -445,7 +445,8 @@ var ExpressionManager = (function () {
         return arr;
       }
       return this.pv + addedAmps[0] + (-amp + amp * 2 * BMMath.random()) * perc;
-    }.bind(this);
+    }
+    wiggle.bind(this);
 
     if (thisProperty.loopIn) {
       loopIn = thisProperty.loopIn.bind(thisProperty);


### PR DESCRIPTION
## Problem

When running Rollup on this library with the default behavior, it produces invalid JS:

```js
// original (valid)
var wiggle = function wiggle(freq, amp) {
  // …
}.bind(this);

// rollup (invalid)
function wiggle(freq, amp) {
  // …
}.bind(this);
```

This is because it sees `var wiggle` is unused, which it is. It also occupies the same namespace as `function wiggle`.

## Changes

This makes a simple change to the code. This makes it easier for Rollup (and other bundlers) to handle, with an invisible change:

```diff
- var wiggle = function wiggle(freq, amp) {
+ function wiggle(freq, amp) {
  // …
- }.bind(this);
+ }
+ wiggle.bind(this);
```

This is much easier for bundlers to prepare.