### PR TITLE
Fix wrong transform calculations on element's first frame

### DIFF
--- a/player/js/utils/TransformProperty.js
+++ b/player/js/utils/TransformProperty.js
@@ -35,7 +35,7 @@ var TransformPropertyFactory = (function () {
     }
   }
   function processKeys(forceRender) {
-    if (this.elem.globalData.frameId === this.frameId) {
+    if (this.elem.globalData.frameId === this.frameId && !this.elem._isFirstFrame) {
       return;
     }
     if (this._isDirty) {


### PR DESCRIPTION
When the first frame for an element is being rendered, the transform calculations are wrong because they are skipped by a condition in `TransformProperty.prepareKeys`. This PR changes the condition so that unnecessary re-calculations are prevented but not on the first render.



Example has more comments and details: https://codepen.io/jadhavm/pen/YzpQZVN