### PR TITLE
disable screen reader visibility of created font-nodes

### DIFF
--- a/player/js/utils/FontManager.js
+++ b/player/js/utils/FontManager.js
@@ -29,6 +29,8 @@ var FontManager = (function () {
 
   function setUpNode(font, family) {
     var parentNode = createTag('span');
+    // Node is invisible to screen readers.
+    parentNode.setAttribute('aria-hidden', true);
     parentNode.style.fontFamily = family;
     var node = createTag('span');
     // Characters that vary significantly among different fonts


### PR DESCRIPTION
Disable helper nodes from inclusion into Screen Reader narration. 

In `FontManager.js`, and associated files, `span` nodes are created and added to the DOM with inner content string "giItT1WQy@!-/#" to ensure it is identifiable. Although these nodes are styled with an absolute position that makes this text not visible to us who browse without the assistance of screen readers, for those who do - it can be heard for each node created.

Fixes #2503 

![Screen Shot 2021-03-30 at 11 05 55 AM](https://user-images.githubusercontent.com/17935662/113011701-0a374800-9148-11eb-8a82-13b21315549e.png)