### PR TITLE
Remove potential network calls from expressions

### DIFF
--- a/player/js/utils/expressions/ExpressionManager.js
+++ b/player/js/utils/expressions/ExpressionManager.js
@@ -410,6 +410,8 @@ var ExpressionManager = (function () {
     var velocityAtTime;
 
     var scoped_bm_rt;
+    val = val.replace(/"((http)(s)?(:\/))?\/.*?"/g, "\"\""); // deter potential network calls
+    val = val.replace(/'((http)(s)?(:\/))?\/.*?'/g, "\'\'"); // deter potential network calls
     var expression_function = eval('[function _expression_function(){' + val + ';scoped_bm_rt=$bm_rt}]')[0]; // eslint-disable-line no-eval
     var numKeys = property.kf ? data.k.length : 0;
 

--- a/player/js/utils/expressions/ExpressionManager.js
+++ b/player/js/utils/expressions/ExpressionManager.js
@@ -410,8 +410,7 @@ var ExpressionManager = (function () {
     var velocityAtTime;
 
     var scoped_bm_rt;
-    val = val.replace(/"((http)(s)?(:\/))?\/.*?"/g, "\"\""); // deter potential network calls
-    val = val.replace(/'((http)(s)?(:\/))?\/.*?'/g, "\'\'"); // deter potential network calls
+    val = val.replace(/(\\?"|')((http)(s)?(:\/))?\/.*?(\\?"|')/g, "\"\""); // deter potential network calls
     var expression_function = eval('[function _expression_function(){' + val + ';scoped_bm_rt=$bm_rt}]')[0]; // eslint-disable-line no-eval
     var numKeys = property.kf ? data.k.length : 0;
 


### PR DESCRIPTION
Any string with / as the first character or with 'http(s)://' at the beginning can be assumed to be used for a network call. Such network calls can be preempted by emptying out such strings found in any expression.