### PR TITLE
Made canResizeFont work with width too

### DIFF
--- a/player/js/utils/text/TextProperty.js
+++ b/player/js/utils/text/TextProperty.js
@@ -208,6 +208,7 @@ TextProperty.prototype.completeTextData = function (documentData) {
       len = finalText.length;
       trackingOffset = (documentData.tr / 1000) * documentData.finalSize;
       var lastSpaceIndex = -1;
+      var widthExceed = false;
       for (i = 0; i < len; i += 1) {
         charCode = finalText[i].charCodeAt(0);
         newLineFlag = false;
@@ -231,6 +232,7 @@ TextProperty.prototype.completeTextData = function (documentData) {
           } else {
             i = lastSpaceIndex;
           }
+          widthExceed = true;
           currentHeight += documentData.finalLineHeight || documentData.finalSize * 1.2;
           finalText.splice(i, lastSpaceIndex === i ? 1 : 0, '\r');
           // finalText = finalText.substr(0,i) + "\r" + finalText.substr(i === lastSpaceIndex ? i + 1 : i);
@@ -242,7 +244,7 @@ TextProperty.prototype.completeTextData = function (documentData) {
         }
       }
       currentHeight += (fontData.ascent * documentData.finalSize) / 100;
-      if (this.canResize && documentData.finalSize > this.minimumFontSize && boxHeight < currentHeight) {
+      if (this.canResize && documentData.finalSize > this.minimumFontSize && (boxHeight < currentHeight || widthExceed)) {
         documentData.finalSize -= 1;
         documentData.finalLineHeight = (documentData.finalSize * documentData.lh) / documentData.s;
       } else {


### PR DESCRIPTION
Text.canResizeFont was working based on height of the text box. This PR extends the same concept to respect width as well. Meaning that if text extends beyond width, instead of breaking into new line, it will try to reduce its font size first, upto the configured limit