### PR TITLE
Fix AnimationConfig types (without breaking type compatibility)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ export type AnimationDirection = 1 | -1;
 export type AnimationSegment = [number, number];
 export type AnimationEventName = 'enterFrame' | 'loopComplete' | 'complete' | 'segmentStart' | 'destroy' | 'config_ready' | 'data_ready' | 'DOMLoaded' | 'error' | 'data_failed' | 'loaded_images';
 export type AnimationEventCallback<T = any> = (args: T) => void;
+export type AnimationRenderer = 'svg' | 'canvas' | 'html';
 
 export type AnimationItem = {
     name: string;
@@ -76,7 +77,7 @@ export type HTMLRendererConfig = BaseRendererConfig & {
     hideOnTransparent?: boolean;
 };
 
-export type AnimationConfig<T extends 'svg' | 'canvas' | 'html' = 'svg'> = {
+export type AnimationConfig<T extends AnimationRenderer = 'svg'> = {
     container: Element;
     renderer?: T;
     loop?: boolean | number;
@@ -98,11 +99,11 @@ export type AnimationConfig<T extends 'svg' | 'canvas' | 'html' = 'svg'> = {
     }
 }
 
-export type AnimationConfigWithPath = AnimationConfig & {
+export type AnimationConfigWithPath<T extends AnimationRenderer> = AnimationConfig<T> & {
     path?: string;
 }
 
-export type AnimationConfigWithData = AnimationConfig & {
+export type AnimationConfigWithData<T extends AnimationRenderer> = AnimationConfig<T> & {
     animationData?: any;
 }
 
@@ -120,7 +121,7 @@ export type LottiePlayer = {
     setSpeed(speed: number, name?: string): void;
     setDirection(direction: AnimationDirection, name?: string): void;
     searchAnimations(animationData?: any, standalone?: boolean, renderer?: string): void;
-    loadAnimation(params: AnimationConfigWithPath | AnimationConfigWithData): AnimationItem;
+    loadAnimation<T extends AnimationRenderer = AnimationRenderer>(params: AnimationConfigWithPath<T> | AnimationConfigWithData<T>): AnimationItem;
     destroy(name?: string): void;
     registerAnimation(element: Element, animationData?: any): void;
     setQuality(quality: string | number): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -121,7 +121,7 @@ export type LottiePlayer = {
     setSpeed(speed: number, name?: string): void;
     setDirection(direction: AnimationDirection, name?: string): void;
     searchAnimations(animationData?: any, standalone?: boolean, renderer?: string): void;
-    loadAnimation<T extends AnimationRenderer = AnimationRenderer>(params: AnimationConfigWithPath<T> | AnimationConfigWithData<T>): AnimationItem;
+    loadAnimation<T extends AnimationRenderer = 'svg'>(params: AnimationConfigWithPath<T> | AnimationConfigWithData<T>): AnimationItem;
     destroy(name?: string): void;
     registerAnimation(element: Element, animationData?: any): void;
     setQuality(quality: string | number): void;


### PR DESCRIPTION
This is an alternative to #2597 that fixes #2591, without removing types that other repos might be using (since currently, both `AnimationConfigWithPath` & `AnimationConfigWithData` are exported). 

`AnimationConfigWithPath/Data<'canvas' | 'svg' | 'html'>` is a bonus feature too.