### PR TITLE
Fix opencollective links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,27 +322,27 @@ my email is **hernantorrisi@gmail.com**
 ### Code Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
-<a href="https://github.com/airbnb/lottie-web/graphs/contributors"><img src="https://opencollective.com/lottie-web/contributors.svg?width=890&button=false" /></a>
+<a href="https://github.com/airbnb/lottie-web/graphs/contributors"><img src="https://opencollective.com/lottie/contributors.svg?width=890&button=false" /></a>
 
 ### Financial Contributors
 
-Become a financial contributor and help us sustain our community. [[Contribute](https://opencollective.com/lottie-web/contribute)]
+Become a financial contributor and help us sustain our community. [[Contribute](https://opencollective.com/lottie/contribute)]
 
 #### Individuals
 
-<a href="https://opencollective.com/lottie-web"><img src="https://opencollective.com/lottie-web/individuals.svg?width=890"></a>
+<a href="https://opencollective.com/lottie"><img src="https://opencollective.com/lottie/individuals.svg?width=890"></a>
 
 #### Organizations
 
-Support this project with your organization. Your logo will show up here with a link to your website. [[Contribute](https://opencollective.com/lottie-web/contribute)]
+Support this project with your organization. Your logo will show up here with a link to your website. [[Contribute](https://opencollective.com/lottie/contribute)]
 
-<a href="https://opencollective.com/lottie-web/organization/0/website"><img src="https://opencollective.com/lottie-web/organization/0/avatar.svg"></a>
-<a href="https://opencollective.com/lottie-web/organization/1/website"><img src="https://opencollective.com/lottie-web/organization/1/avatar.svg"></a>
-<a href="https://opencollective.com/lottie-web/organization/2/website"><img src="https://opencollective.com/lottie-web/organization/2/avatar.svg"></a>
-<a href="https://opencollective.com/lottie-web/organization/3/website"><img src="https://opencollective.com/lottie-web/organization/3/avatar.svg"></a>
-<a href="https://opencollective.com/lottie-web/organization/4/website"><img src="https://opencollective.com/lottie-web/organization/4/avatar.svg"></a>
-<a href="https://opencollective.com/lottie-web/organization/5/website"><img src="https://opencollective.com/lottie-web/organization/5/avatar.svg"></a>
-<a href="https://opencollective.com/lottie-web/organization/6/website"><img src="https://opencollective.com/lottie-web/organization/6/avatar.svg"></a>
-<a href="https://opencollective.com/lottie-web/organization/7/website"><img src="https://opencollective.com/lottie-web/organization/7/avatar.svg"></a>
-<a href="https://opencollective.com/lottie-web/organization/8/website"><img src="https://opencollective.com/lottie-web/organization/8/avatar.svg"></a>
-<a href="https://opencollective.com/lottie-web/organization/9/website"><img src="https://opencollective.com/lottie-web/organization/9/avatar.svg"></a>
+<a href="https://opencollective.com/lottie/organization/0/website"><img src="https://opencollective.com/lottie/organization/0/avatar.svg"></a>
+<a href="https://opencollective.com/lottie/organization/1/website"><img src="https://opencollective.com/lottie/organization/1/avatar.svg"></a>
+<a href="https://opencollective.com/lottie/organization/2/website"><img src="https://opencollective.com/lottie/organization/2/avatar.svg"></a>
+<a href="https://opencollective.com/lottie/organization/3/website"><img src="https://opencollective.com/lottie/organization/3/avatar.svg"></a>
+<a href="https://opencollective.com/lottie/organization/4/website"><img src="https://opencollective.com/lottie/organization/4/avatar.svg"></a>
+<a href="https://opencollective.com/lottie/organization/5/website"><img src="https://opencollective.com/lottie/organization/5/avatar.svg"></a>
+<a href="https://opencollective.com/lottie/organization/6/website"><img src="https://opencollective.com/lottie/organization/6/avatar.svg"></a>
+<a href="https://opencollective.com/lottie/organization/7/website"><img src="https://opencollective.com/lottie/organization/7/avatar.svg"></a>
+<a href="https://opencollective.com/lottie/organization/8/website"><img src="https://opencollective.com/lottie/organization/8/avatar.svg"></a>
+<a href="https://opencollective.com/lottie/organization/9/website"><img src="https://opencollective.com/lottie/organization/9/avatar.svg"></a>


### PR DESCRIPTION
These should all point to opencollective.com/lottie and not
opencollective.com/lottie-web, which is currently controlled
by a security researcher.