### PR TITLE
Typescript: Make loadAnimation take the renderer specified for correct AnimationConfig

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -76,7 +76,9 @@ export type HTMLRendererConfig = BaseRendererConfig & {
     hideOnTransparent?: boolean;
 };
 
-export type AnimationConfig<T extends 'svg' | 'canvas' | 'html' = 'svg'> = {
+type Renderers = 'svg' | 'canvas' | 'html';
+
+export type AnimationConfig<T extends Renderers = 'svg'> = {
     container: Element;
     renderer?: T;
     loop?: boolean | number;
@@ -98,11 +100,11 @@ export type AnimationConfig<T extends 'svg' | 'canvas' | 'html' = 'svg'> = {
     }
 }
 
-export type AnimationConfigWithPath = AnimationConfig & {
+export type AnimationConfigWithPath<T extends Renderers = 'svg'> = AnimationConfig<T> & {
     path?: string;
 }
 
-export type AnimationConfigWithData = AnimationConfig & {
+export type AnimationConfigWithData<T extends Renderers = 'svg'> = AnimationConfig<T> & {
     animationData?: any;
 }
 
@@ -120,7 +122,7 @@ export type LottiePlayer = {
     setSpeed(speed: number, name?: string): void;
     setDirection(direction: AnimationDirection, name?: string): void;
     searchAnimations(animationData?: any, standalone?: boolean, renderer?: string): void;
-    loadAnimation(params: AnimationConfigWithPath | AnimationConfigWithData): AnimationItem;
+    loadAnimation<T extends Renderers>(params: AnimationConfigWithPath<T> | AnimationConfigWithData<T>): AnimationItem;
     destroy(name?: string): void;
     registerAnimation(element: Element, animationData?: any): void;
     setQuality(quality: string | number): void;


### PR DESCRIPTION
When using `loadAnimation`, if you specify anything other than `svg`, renderer will be incorrectly typed with the following error.

> Type '"svg" | "canvas" | "html"' is not assignable to type '"svg" | undefined'.
  Type '"canvas"' is not assignable to type '"svg" | undefined'

This is due to loadAnimation not passing in a type that was used to call it, and then AnimationConfig picks up the default value it assigns when nothing is specified. This change makes all of the types still be allowed to be used without explicit types as before, but will forward on the correct generic type when calling `loadAnimation`, allowing for `canvas` or `html`. 