### PR TITLE
Fix ts typing for loadAnimation parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 export type AnimationDirection = 1 | -1;
 export type AnimationSegment = [number, number];
-export type AnimationEventName = 'enterFrame' | 'loopComplete' | 'complete' | 'segmentStart' | 'destroy' | 'config_ready' | 'data_ready' | 'DOMLoaded' | 'error' | 'data_failed' | 'loaded_images';
+export type AnimationEventName = 'enterFrame' | 'loopComplete' | 'complete' | 'segmentStart' | 'destroy' | 'config_ready' | 'data_ready' | 'DOMLoaded' | 'error' | 'data_failed' | 'loaded_images';
 export type AnimationEventCallback<T = any> = (args: T) => void;
 
 export type AnimationItem = {
@@ -76,7 +76,9 @@ export type HTMLRendererConfig = BaseRendererConfig & {
     hideOnTransparent?: boolean;
 };
 
-export type AnimationConfig<T extends 'svg' | 'canvas' | 'html' = 'svg'> = {
+export type RendererType = 'svg' | 'canvas' | 'html';
+
+export type AnimationConfig<T extends RendererType> = {
     container: Element;
     renderer?: T;
     loop?: boolean | number;
@@ -98,11 +100,11 @@ export type AnimationConfig<T extends 'svg' | 'canvas' | 'html' = 'svg'> = {
     }
 }
 
-export type AnimationConfigWithPath = AnimationConfig & {
+export type AnimationConfigWithPath<T extends RendererType> = AnimationConfig<T> & {
     path?: string;
 }
 
-export type AnimationConfigWithData = AnimationConfig & {
+export type AnimationConfigWithData<T extends RendererType> = AnimationConfig<T> & {
     animationData?: any;
 }
 
@@ -120,7 +122,7 @@ export type LottiePlayer = {
     setSpeed(speed: number, name?: string): void;
     setDirection(direction: AnimationDirection, name?: string): void;
     searchAnimations(animationData?: any, standalone?: boolean, renderer?: string): void;
-    loadAnimation(params: AnimationConfigWithPath | AnimationConfigWithData): AnimationItem;
+    loadAnimation<T extends RendererType>(params: AnimationConfigWithPath<T> | AnimationConfigWithData<T>): AnimationItem;
     destroy(name?: string): void;
     registerAnimation(element: Element, animationData?: any): void;
     setQuality(quality: string | number): void;


### PR DESCRIPTION
Currently the parameter type for `loadAnimation` does not allow for non `svg` renderers, as seen in this [typescript playground](https://www.typescriptlang.org/play?#code/KYDwDg9gTgLgBDAnmYcCCA7AlgWwIYxYQYAiWUwAxocXALxwCMcAPnALSMDcAUKJLATJUmXASIYAysADmOYBngMA2hgCuOAEbAoAGjjqtOgLq9+0eEhTps+GhgCiANwUwAcnnn04Aclc6AMShPYB9WXwAbCAgwAGEIHDAI4BhQ8J9KBKSUtLYfAGdZeUVJGDxYMLyAE2B8mCgIRErfTIwAMywZAH0KPCqm9KqCPB7gPoG8kgB5AFkAGQg+4CrmvygGqFWhsq62vCxklfSopaqusRlanzNwCyFrUTsJZ1dYvAiIzTxKAGsAHgAKt48BhEAA+bwACnKMnyAC44ACAJT0CFOCBYKq8Pi3QRWES2cTEACSqRw3gA3jw4DSDCEEXUoFgMDJeLS4Fh8gtTgjNNFkiC2bTKGp1q4gvSDBptFAhTSRWLFAAlPAAdwl8gRhhlcrgHSgdQ1wC10p0upgEDKESN8KlRll1NpbWC8hVqRN9t1zpCMzUERgHp1jppSTwiEkKGWgbNwbgocQZAo1Ak0Yd7Pj8TUilTus5AAU8GpClVefyxhhdYWLfHSxABRXY1EYrX67qKBgahQoAiQYhK4T7MSSAz6szWbG8PlCjB8gWYAALEdMlnm3DAeKJZKpEt2oPswpyVx5iC27Ux9mcyRqTTe+QODB4TSHFvl3UH4ozhGPIlSIqucLfvY0iHooyimLG8aQg+8gAPxLmOSIIuimJvtWUEhHBcCMghSEYlisYWjIMjJAWRbAOhsHwSyiFwMh+HsjUjKNBRwCYdh1G4ShEGFoULFsaOHG0XhuoyBAAIQJgVSlDEkJOO8ajGruOj6JyRqYXydblvo0GsVRMg0XRIliRJHZ5hEYayfJilnnoHL5GpL4gtpGF6QZwmxsylARGoNRzGGOj5JC2x4D2oJuVx+4pMBH6QsyWABkptkKDuNnhfRtIUNO0WuIFbTQJQwABOZMiORgaW6vOmLkeVsb5POECqpCNXsplWAAF7VZx6U0llkZVJC+R9amzW0tOiZUPYQXkBNKY2GI9jjcmxAjSG5nhn+iiBe+OVfgOEjZYoAF7cQB0wGB+h5VABVFXgMjqWWIIrVhUXXre5FkVemg2qVT2XDAJCij+sUYDa92aY9OYEUyRE6C8iiAsCoJgixu3zc8LiKB48j6DCtrIl1lZVFUcMwHMnKpBgOgIwwvbIzpqNPMQJNY8A+iUO8nzfD8DM-iTbwfF8vyAmCNFNaiQkRRlwA4BALgk2TdQKFTQI00jKNzYzjgY+4IRsxzgs-JhgHo68+tc8LNUAL48DiAiWMIcAAEKTsASrJToOjxO0nSUh5+CXHmmU6C4aCDRNbpEPxy7juyXmTvkLNR2OvCW9i5h4g7kgAGoAOJux2HtQF7HQyN4zuFPnnae8QJdwAAZHAVLsoQMDJEnK6xoxlBMmA9jtzHtJgEHUAh2H1ARxA-e6kPEAyJl+RYC43JVGDraxpVNRTBgALBBgg3lK4q+vrGThYMAqqOxAIBbxEiBH4KJ9nxfV+SO1ulYQJA80nlIr5I+belS9AcVIUBX4dUwgEYBOgwHrhrp0FOadcT22sG8DAcl8iV0LsXH2DBy6u3dl2bBpcG5N2FAKIuIJ0H3wbLHYgqQQAwEwqg9BmDo5e3oTAAATCQaeDQ561AXkvRYK9AEQWHqPFA48iRTx4KnG26dkGoAABIAnmKw6u3tS64JduooucDiGN3XlVLeO8QT73bIw0RcjbZ3HxBrH8RCEagAplUfIvh8hOBkKsdmaDJyrHnDAHAEQwgMAKJ4nwEIGCkPlHQ-YlNuxwAcMkD8bYCE6EwgCXUTYwDUPCDZSsahqxrWobmbAhB3inSNsdX8IEYC6h0jI9k8cUizgIPORpUsC5dmkDAQgLJ8iYWieyLCniETZzzmkvRmjdSx0oZOBEzDJy6KITM2kASgkIhUWoyZKzYyW2UACYwE4fJEACN8C0UA77QinCkOci4P7RxokM9Ma0mpdVjJFYAPw3kSyqB8wea0xw-Lov8mkwRUjArwqC56MAs51g0J1X5ezZHyKQfcAkaNiBEIAOrxXnHc7wxssX6ProY9MbSZHWxsRnB41ScV4pIMMQldKSUkInNUxlZRMK9hTqiu26K4CQP9NAt+RDfbslVJiBcekKrAE6AEmVsYQCKvZIgRV1iFECoWL0s+Zl-JQHFQCiyDTXIE24mRPiprfmoRkiah5OFrW1Sin1AaQ1ErOUovawShknX-WmktDAU0kz2B5gtf19gPXv3YvpM1kVyiUHnESve0IOXDG5aCfQdQQRDCiJTah+h2xVygP3J6JwqhJshGAconhbRJvpQuAlbA636NxQuTleAaJJtJNLXUjF6jMTtdGp6FAZDkx0BW4AyTXAIiSdLVwONU1ctCogJ604ACKah3jxUQJCAAjpuiI269J5NNFAVdKQFjs3sEoigbRITzlvVan11iahxwoHAVodQ4DasIIpH9uq1oxmpfAGoew-TwH-cAbEW44ARARJBvViAYwRAAHRlorUM1oZRmQ6ARBSS2cBJyEYzbGQthcEQZDmfkHwuhSOTJ6X02EeHoVeTGBQ3xtp6gKVo8M2kp9z6X2vhgW+CI9gREKMiy2SIgA).

