### PR TITLE
Make `AnimationItem` type indicate that the `loop` property can be `boolean | number`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ export type AnimationItem = {
     playCount: number;
     isPaused: boolean;
     autoplay: boolean;
-    loop: boolean;
+    loop: boolean | number;
     renderer: any;
     animationID: string;
     assetsPath: string;


### PR DESCRIPTION
Make `AnimationItem` type indicate that the `loop` property can be `boolean | number` instead of just `boolean`.