### PR TITLE
Fix script renderer check

### DIFF
--- a/player/js/module.js
+++ b/player/js/module.js
@@ -132,14 +132,13 @@ function getQueryVariable(variable) {
 var standalone = '__[STANDALONE]__';
 var animationData = '__[ANIMATIONDATA]__';
 var renderer = '';
-var queryString;
+var queryString = '';
 if (standalone) {
   var scripts = document.getElementsByTagName('script');
   var index = scripts.length - 1;
-  var myScript = scripts[index] || {
-    src: '',
-  };
-  queryString = myScript.src.replace(/^[^\?]+\??/, ''); // eslint-disable-line no-useless-escape
+  if (scripts[index] && scripts[index].src) {
+    queryString = scripts[index].src.replace(/^[^\?]+\??/, ''); // eslint-disable-line no-useless-escape
+  }
   renderer = getQueryVariable('renderer');
 }
 var readyStateCheckInterval = setInterval(checkReady, 100);


### PR DESCRIPTION
We have many dynamically loaded scripts and one of the problems we're facing is
 `Cannot read properties of null (reading 'replace')`
Base on definition scripts do not need src property so that's why I changed a little bit way of checking that 