### PR TITLE
Use existing offscreen canvas via animationParams in lottie_worker

### DIFF
--- a/player/js/module_worker.js
+++ b/player/js/module_worker.js
@@ -647,16 +647,18 @@ var lottie = (function () {
           animation.container = animationParams.container;
           delete animationParams.container;
         }
-        if (animationParams.renderer === 'canvas' && !animationParams.rendererSettings.canvas) {
-          var canvas = document.createElement('canvas');
-          animation.container.appendChild(canvas);
-          canvas.width = animationParams.animationData.w;
-          canvas.height = animationParams.animationData.h;
-          canvas.style.width = '100%';
-          canvas.style.height = '100%';
-          var offscreen = canvas.transferControlToOffscreen();
-          transferedObjects.push(offscreen);
-          animationParams.rendererSettings.canvas = offscreen;
+        if (animationParams.renderer === 'canvas') {
+          if (!animationParams.rendererSettings.canvas) {
+            var canvas = document.createElement('canvas');
+            animation.container.appendChild(canvas);
+            canvas.width = animationParams.animationData.w;
+            canvas.height = animationParams.animationData.h;
+            canvas.style.width = '100%';
+            canvas.style.height = '100%';
+            var offscreen = canvas.transferControlToOffscreen();
+            animationParams.rendererSettings.canvas = offscreen;
+          }
+          transferedObjects.push(animationParams.rendererSettings.canvas);
         }
         animations[animationId] = animation;
         workerInstance.postMessage({


### PR DESCRIPTION
When using the module_worker with the following settings:
```javascript
{
  renderer: 'canvas',
  rendererSettings: {
    canvas: <existing-canvas>
  }
}
```

then, the current logic would not add the existing (offscreen) canvas to `transferedObjects`.

This change adds `animationParams.rendererSettings.canvas` to `transferedObjects`, which allows passing in an existing offscreen canvas.

The alternative would be to expect a regular canvas and do the `transferControlToOffscreen()` for both cases, too.