### PR TITLE
Add type for goToAndPlay & goToAndStop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,8 +30,8 @@ export type AnimationItem = {
     togglePause(name?: string): void;
     destroy(name?: string): void;
     pause(name?: string): void;
-    goToAndStop(value: number, isFrame?: boolean, name?: string): void;
-    goToAndPlay(value: number, isFrame?: boolean, name?: string): void;
+    goToAndStop(value: number | string, isFrame?: boolean, name?: string): void;
+    goToAndPlay(value: number | string, isFrame?: boolean, name?: string): void;
     includeLayers(data: any): void;
     setSegment(init: number, end: number): void;
     resetSegments(forceFlag: boolean): void;


### PR DESCRIPTION
Add type `string` for value to support named marker, we noticed in goToAndStop & goToAndPlay [source code](https://github.com/airbnb/lottie-web/blob/752f1226b17c8b30c0794cc857a5b2fcc63009f8/player/js/animation/AnimationItem.js#L446), there is a check for value isNaN(numValue) if it is a string and the function will return a marker in both cases.