### PR TITLE
Add dataFailed property to animationItem

### DIFF
--- a/player/js/animation/AnimationItem.js
+++ b/player/js/animation/AnimationItem.js
@@ -27,6 +27,7 @@ const AnimationItem = function () {
   this.name = '';
   this.path = '';
   this.isLoaded = false;
+  this.dataFailed = false;
   this.currentFrame = 0;
   this.currentRawFrame = 0;
   this.firstFrame = 0;
@@ -113,6 +114,7 @@ AnimationItem.prototype.setParams = function (params) {
 };
 
 AnimationItem.prototype.onSetupError = function () {
+  this.dataFailed = true;
   this.trigger('data_failed');
 };
 


### PR DESCRIPTION
Enables knowing whether an animationItem failed to load. This is useful when looping through animations from methods like getRegisteredAnimations(). Without this, there doesn't seem to be a way to tell if an animationItem is pending load vs failed to load by simply looking at static properties because onSetupError records no state.

closes #2758 