### PR TITLE
Expand the hybrid shape bounding box on stroke

### DIFF
--- a/player/js/elements/htmlElements/HShapeElement.js
+++ b/player/js/elements/htmlElements/HShapeElement.js
@@ -191,7 +191,13 @@ HShapeElement.prototype.calculateBoundingBox = function (itemsData, boundingBox)
 HShapeElement.prototype.expandStrokeBoundingBox = function (widthProperty, boundingBox) {
   var width = 0;
   if (widthProperty.keyframes) {
-    width = Math.max(...widthProperty.keyframes.map(kf => (kf.s ?? 0) * widthProperty.mult));
+    for ( var i = 0; i < widthProperty.keyframes.length; i++ ) {
+      var kfw = widthProperty.keyframes[i].s;
+      if ( kfw > width ) {
+        width = kfw;
+      }
+    }
+    width *= widthProperty.mult;
   } else {
     width = widthProperty.v * widthProperty.mult;
   }

--- a/player/js/elements/htmlElements/HShapeElement.js
+++ b/player/js/elements/htmlElements/HShapeElement.js
@@ -182,8 +182,24 @@ HShapeElement.prototype.calculateBoundingBox = function (itemsData, boundingBox)
       this.calculateShapeBoundingBox(itemsData[i], boundingBox);
     } else if (itemsData[i] && itemsData[i].it) {
       this.calculateBoundingBox(itemsData[i].it, boundingBox);
+    } else if (itemsData[i] && itemsData[i].style && itemsData[i].w ) {
+      this.expandStrokeBoundingBox(itemsData[i].w, boundingBox);
     }
   }
+};
+
+HShapeElement.prototype.expandStrokeBoundingBox = function (widthProperty, boundingBox) {
+  var width = 0;
+  if (widthProperty.keyframes) {
+    width = Math.max(...widthProperty.keyframes.map(kf => (kf.s ?? 0) * widthProperty.mult));
+  } else {
+    width = widthProperty.v * widthProperty.mult;
+  }
+
+  boundingBox.x -= width;
+  boundingBox.xMax += width;
+  boundingBox.y -= width;
+  boundingBox.yMax += width;
 };
 
 HShapeElement.prototype.currentBoxContains = function (box) {


### PR DESCRIPTION
I noticed that with `html` renderer shapes with thick strokes were cut off.

This PR fixes the issue by expanding the bounding box when a stroke shape is present.

Here's a render comparison:
![Screenshot_20220511_172602](https://user-images.githubusercontent.com/2465791/167888065-fb9fc0ac-15d9-4e96-82ad-5f0e966d520d.png) ![Screenshot_20220511_172541](https://user-images.githubusercontent.com/2465791/167888070-f476bf1e-d28a-46c5-9e34-f0c701ca054c.png)
