### PR TITLE
Properly handle offset path for open shapes

### DIFF
--- a/player/js/utils/PolynomialBezier.js
+++ b/player/js/utils/PolynomialBezier.js
@@ -199,6 +199,11 @@ PolynomialBezier.shapeSegment = function (shapePath, index) {
   return new PolynomialBezier(shapePath.v[index], shapePath.o[index], shapePath.i[nextIndex], shapePath.v[nextIndex], true);
 };
 
+PolynomialBezier.shapeSegmentInverted = function (shapePath, index) {
+  var nextIndex = (index + 1) % shapePath.length();
+  return new PolynomialBezier(shapePath.v[nextIndex], shapePath.i[nextIndex], shapePath.o[index], shapePath.v[index], true);
+};
+
 function crossProduct(a, b) {
   return [
     a[1] * b[2] - a[2] * b[1],


### PR DESCRIPTION
Small change to offset path, to handle open shapes properly (it creates a full stroke like in AE rather than just offsetting)

![Screenshot_20220727_101703](https://user-images.githubusercontent.com/2465791/181197727-c5b611f0-ba1e-40e1-83f5-3a4124164aea.png)



By the way when creating PRs, I avoid committing files under `build/` to make it easier to review, do let me know if you'd rather have them though.