### PR TITLE
ZigZag based on bezier length

### DIFF
--- a/player/js/utils/shapes/ZigZagModifier.js
+++ b/player/js/utils/shapes/ZigZagModifier.js
@@ -29,13 +29,13 @@ function zigZagCorner(outputBezier, segmentBefore, segmentAfter, amplitude, dire
 
   if (!segmentBefore) {
     point = segmentAfter.points[0];
-    angle = segmentAfter.normalAngle(0);
+    angle = segmentAfter.normalAngle(0.01);
   } else if (!segmentAfter) {
     point = segmentBefore.points[3];
-    angle = segmentBefore.normalAngle(1);
+    angle = segmentBefore.normalAngle(0.99);
   } else {
     point = segmentAfter.points[0];
-    angle = angleMean(segmentAfter.normalAngle(0), segmentBefore.normalAngle(1));
+    angle = angleMean(segmentAfter.normalAngle(0.01), segmentBefore.normalAngle(0.99));
   }
 
   var px = point[0] + Math.cos(angle) * direction * amplitude;
@@ -45,7 +45,8 @@ function zigZagCorner(outputBezier, segmentBefore, segmentAfter, amplitude, dire
 
 function zigZagSegment(outputBezier, segment, amplitude, frequency, direction) {
   for (var i = 0; i < frequency; i += 1) {
-    var t = (i + 1) / (frequency + 1);
+    var f = (i + 1) / (frequency + 1);
+    var t = segment.tAtLengthPercent(f);
     var angle = segment.normalAngle(t);
     var point = segment.point(t);
     var px = point[0] + Math.cos(angle) * direction * amplitude;


### PR DESCRIPTION
Updates ZigZag to split bezier into uniform length rather than splitting the bezier parameter.

To calculate the lengths I approximate the bezier segment with 20 linear segments, based on some visual tests, at around 20 segments the results are very accurate (at most 1 pixel off on large/wild beziers).
This value can be lowered for a performance / accuracy tradeoff.

I also tweaked a bit the position of the endpoints as it was slightly off.