### PR TITLE
Fix char data with empty shapes

### DIFF
--- a/player/js/utils/DataManager.js
+++ b/player/js/utils/DataManager.js
@@ -239,7 +239,7 @@ const dataManager = (function () {
                 var len = animationData.chars.length;
                 for (i = 0; i < len; i += 1) {
                   var charData = animationData.chars[i];
-                  if (charData.data && charData.data.shapes) {
+                  if (charData.data && charData.data.shapes && charData.data.shapes.length > 0) {
                     completeShapes(charData.data.shapes);
                     charData.data.ip = 0;
                     charData.data.op = 99999;


### PR DESCRIPTION
Fixes errors happening when character data has empty `shapes`.

It could happen sometimes when a character doesn't actually have any shapes (eg: space).
Without this fix, `charData.data.shapes[0].it.push` would throw an exception.