### PR TITLE
Add the xmlns:xlink namespace to the root svg element

### DIFF
--- a/player/js/renderers/SVGRendererBase.js
+++ b/player/js/renderers/SVGRendererBase.js
@@ -44,6 +44,7 @@ SVGRendererBase.prototype.createSolid = function (data) {
 
 SVGRendererBase.prototype.configAnimation = function (animData) {
   this.svgElement.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  this.svgElement.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
   if (this.renderConfig.viewBoxSize) {
     this.svgElement.setAttribute('viewBox', this.renderConfig.viewBoxSize);
   } else {


### PR DESCRIPTION
The XML Xlink namespace is currently used by the `<image>` element (in [`elements/htmlElements/HImageElement.js:28`](https://github.com/airbnb/lottie-web/blob/54cc52da6e7c2cff54fc1df22675a9c0099f551a/player/js/elements/htmlElements/HImageElement.js#L28)). 

However this namespace is not being included in the parent `<svg>` element resulting in a malformed XML that unfortunately breaks some common SVG to Image/Canvas/Texture rendering methods. 

This PR adds the xmlns:xlink attribute to the base `<svg>` element in the svg base renderer.
 
### Some current breakage scenarios that this PR intends to fix:

When rendering the Lottie-web SVG  into a canvas or image an error is thrown if it has `<image>` tags present that use the `xlink` NS attribute.

A malformed XML error happens with the popular svg->canvas rendering lib [canvg](https://github.com/canvg/canvg), or with the vanilla approach of passing the SVG string as an HTMLImageElement src:

```javascript

      const svgString = `data:image/svg+xml,${lottiePlayerSvgElement.outerHTML}`;

      const img = new Image();
      img.onload = (e) => {
        // Never called when the SVG has `<image>` elements.
      };
      img.onerror = (e) => {
        // Called when the SVG has `<image>` elements
      };
      img.src = svgString;
```
