### PR TITLE
Add renderer config that disables expressions

### DIFF
--- a/player/js/renderers/CanvasRenderer.js
+++ b/player/js/renderers/CanvasRenderer.js
@@ -17,6 +17,7 @@ function CanvasRenderer(animationItem, config) {
     contentVisibility: (config && config.contentVisibility) || 'visible',
     className: (config && config.className) || '',
     id: (config && config.id) || '',
+    runExpressions: !config || config.runExpressions === undefined || config.runExpressions,
   };
   this.renderConfig.dpr = (config && config.dpr) || 1;
   if (this.animationItem.wrapper) {

--- a/player/js/renderers/HybridRenderer.js
+++ b/player/js/renderers/HybridRenderer.js
@@ -19,6 +19,7 @@ function HybridRenderer(animationItem, config) {
       x: (config && config.filterSize && config.filterSize.x) || '-100%',
       y: (config && config.filterSize && config.filterSize.y) || '-100%',
     },
+    runExpressions: !config || config.runExpressions === undefined || config.runExpressions,
   };
   this.globalData = {
     _mdf: false,

--- a/player/js/renderers/SVGRenderer.js
+++ b/player/js/renderers/SVGRenderer.js
@@ -58,6 +58,7 @@ function SVGRenderer(animationItem, config) {
     },
     width: (config && config.width),
     height: (config && config.height),
+    runExpressions: !config || config.runExpressions === undefined || config.runExpressions,
   };
 
   this.globalData = {

--- a/player/js/utils/expressions/ExpressionManager.js
+++ b/player/js/utils/expressions/ExpressionManager.js
@@ -382,6 +382,14 @@ const ExpressionManager = (function () {
   }
 
   function initiateExpression(elem, data, property) {
+    // Bail out if we don't want expressions
+    function noOp(_value) {
+      return _value;
+    }
+    if (!elem.globalData.renderConfig.runExpressions) {
+      return noOp;
+    }
+
     var val = data.x;
     var needsVelocity = /velocity(?![\w\d])/.test(val);
     var _needsRandom = val.indexOf('random') !== -1;
@@ -666,13 +674,6 @@ const ExpressionManager = (function () {
     var parent;
     var randSeed = Math.floor(Math.random() * 1000000);
     var globalData = elem.globalData;
-
-    function noOp(_value) {
-      return _value;
-    }
-    if (!globalData.renderConfig.runExpressions) {
-      return noOp;
-    }
 
     function executeExpression(_value) {
       // globalData.pushExpression();

--- a/player/js/utils/expressions/ExpressionManager.js
+++ b/player/js/utils/expressions/ExpressionManager.js
@@ -666,6 +666,14 @@ const ExpressionManager = (function () {
     var parent;
     var randSeed = Math.floor(Math.random() * 1000000);
     var globalData = elem.globalData;
+
+    function noOp(_value) {
+      return _value;
+    }
+    if (!globalData.renderConfig.runExpressions) {
+      return noOp;
+    }
+
     function executeExpression(_value) {
       // globalData.pushExpression();
       value = _value;


### PR DESCRIPTION
This adds a setting that disables expressions (they are kept enabled by default). This is to add some security when you don't want animations to run javascript on your page.

Passing something like this to `loadAnimation()` will ensure expressions are not executed:

```js
    {
        container: document.getElementById('lottie_container'),
        renderer: 'svg',
        loop: true,
        autoplay: true,
        animationData: data,
        rendererSettings: {
            runExpressions: false,
        }
    }
```