### PR TITLE
fix(interpolation): fix bezier interpolation between same values

### DIFF
--- a/player/js/utils/PropertyFactory.js
+++ b/player/js/utils/PropertyFactory.js
@@ -173,7 +173,14 @@ const PropertyFactory = (function () {
           }
 
           endValue = nextKeyData.s || keyData.e;
-          keyValue = keyData.h === 1 ? keyData.s[i] : keyData.s[i] + (endValue[i] - keyData.s[i]) * perc;
+
+          if (keyData.h === 1) {
+            keyValue = keyData.s[i];
+          } else if (endValue[i] === keyData.s[i]) {
+            keyValue = keyData.s[i] + perc;
+          } else {
+            keyValue = keyData.s[i] + (endValue[i] - keyData.s[i]) * perc;
+          }
 
           if (this.propType === 'multidimensional') {
             newValue[i] = keyValue;


### PR DESCRIPTION
I've reported issue https://github.com/airbnb/lottie-web/issues/2840

This PR solves this value.
Change is pretty small but maybe not obvious why it is legal here to multiply curve value with 1.

So, as we know according [lottie docs](https://lottiefiles.github.io/lottie-docs/concepts/#animated-property) keyframe describes easing handling (cubic bezier) between current keyframe and next keyframe values. 
It contains 2 base points with coordinates [0,0] [1,1], and control points are stored in `in`, `out` properties.

This is regular example how it can look like https://cubic-bezier.com/#.2,1.44,.7,.31
Let's say we are animating between values [10, 20]
It's easy to interpolate.

```
const newVal = currentKeyframe.s[i] + (nextKeyframe.s[i] - currentKeyframe.s[i]) * curve.getValue(percentage);

// (nextKeyframe.s[i] - currentKeyframe.s[i]) * curve.getValue(percentage) - describes increment
```
And it's obvious that when percentage is 100 newVal is

```
const newVal = currentKeyframe.s[i] + (nextKeyframe.s[i] - currentKeyframe.s[i]) * 1; // => 
const newVal = nextKeyframe.s[i];
```
which make sense;

In our case we are interpolating between same value;
which actually means that [1,1] point is equal to [1,0] point because there is no difference between values.
In this case curve describes increment itself.

