### PR TITLE
fix wrong updateDocumentData name on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Animation instances have these main methods:
 ***
 
 ### Additional methods:
-- updateTextDocumentData -- updates a text layer's data
+- updateDocumentData -- updates a text layer's data
 [More Info](https://github.com/airbnb/lottie-web/wiki/TextLayer.updateDocumentData)
 ***
 


### PR DESCRIPTION
fix wrong method name

wiki: https://github.com/airbnb/lottie-web/wiki/TextLayer.updateDocumentData#usage
code: https://github.com/airbnb/lottie-web/search?q=updateDocumentData
