### PR TITLE
fix: Do not operate DOM when rendering with external elements

### DIFF
--- a/player/js/renderers/CanvasRendererBase.js
+++ b/player/js/renderers/CanvasRendererBase.js
@@ -353,11 +353,15 @@ CanvasRendererBase.prototype.checkPendingElements = function () {
 };
 
 CanvasRendererBase.prototype.hide = function () {
-  this.animationItem.container.style.display = 'none';
+  if (this.animationItem.container) {
+    this.animationItem.container.style.display = 'none';
+  }
 };
 
 CanvasRendererBase.prototype.show = function () {
-  this.animationItem.container.style.display = 'block';
+  if (this.animationItem.container) {
+    this.animationItem.container.style.display = 'block';
+  }
 };
 
 export default CanvasRendererBase;


### PR DESCRIPTION
The reason: playSegments will throw error when rendering with external elements.