### PR TITLE
90 canvas matte masks

### DIFF
--- a/player/js/elements/canvasElements/CVBaseElement.js
+++ b/player/js/elements/canvasElements/CVBaseElement.js
@@ -26,9 +26,9 @@ CVBaseElement.prototype = {
     if (this.data.tt >= 1) {
       this.buffers = [];
       var canvasContext = this.globalData.canvasContext;
-      var bufferCanvas = new OffscreenCanvas(canvasContext.canvas.width, canvasContext.canvas.height);
+      var bufferCanvas = assetManager.createCanvas(canvasContext.canvas.width, canvasContext.canvas.height);
       this.buffers.push(bufferCanvas);
-      var bufferCanvas2 = new OffscreenCanvas(canvasContext.canvas.width, canvasContext.canvas.height);
+      var bufferCanvas2 = assetManager.createCanvas(canvasContext.canvas.width, canvasContext.canvas.height);
       this.buffers.push(bufferCanvas2);
       if (this.data.tt >= 3 && !document._isProxy) {
         assetManager.loadLumaCanvas();

--- a/player/js/elements/canvasElements/CVBaseElement.js
+++ b/player/js/elements/canvasElements/CVBaseElement.js
@@ -22,7 +22,7 @@ CVBaseElement.prototype = {
     // This solution is not ideal for several reason. But unfortunately, because of the recursive
     // nature of the render tree, it's the only simple way to make sure one inner mask doesn't override an outer mask.
     // TODO: try to reduce the size of these buffers to the size of the composition contaning the layer
-    // It might be challenging because there layer most likely is transformed in some way
+    // It might be challenging because the layer most likely is transformed in some way
     if (this.data.tt >= 1) {
       this.buffers = [];
       var canvasContext = this.globalData.canvasContext;
@@ -113,7 +113,7 @@ CVBaseElement.prototype = {
         var lumaBufferCtx = lumaBuffer.getContext('2d');
         lumaBufferCtx.drawImage(this.canvasContext.canvas, 0, 0);
         this.clearCanvas(this.canvasContext);
-        // we repaint the context with the mask applied to to
+        // we repaint the context with the mask applied to it
         this.canvasContext.drawImage(lumaBuffer, 0, 0);
       }
       this.canvasContext.globalCompositeOperation = operationsMap[this.data.tt];

--- a/player/js/elements/canvasElements/CVBaseElement.js
+++ b/player/js/elements/canvasElements/CVBaseElement.js
@@ -89,7 +89,7 @@ CVBaseElement.prototype = {
       this.canvasContext.clearRect(0, 0, this.canvasContext.canvas.width, this.canvasContext.canvas.height);
       this.canvasContext.setTransform(this.currentTransform);
       // We draw the mask
-      const mask = this.comp.getElementById(this.data.tp);
+      const mask = this.comp.getElementById('tp' in this.data ? this.data.tp : this.data.ind - 1);
       mask.renderFrame(true);
       // We draw the second buffer (that contains the content of this layer)
       this.canvasContext.setTransform(1, 0, 0, 1, 0, 0);

--- a/player/js/elements/canvasElements/CVBaseElement.js
+++ b/player/js/elements/canvasElements/CVBaseElement.js
@@ -1,4 +1,5 @@
 import getBlendMode from '../../utils/helpers/blendModes';
+import createTag from '../../utils/helpers/html_elements';
 import Matrix from '../../3rd_party/transformation-matrix';
 import CVEffects from './CVEffects';
 import CVMaskElement from './CVMaskElement';
@@ -6,10 +7,31 @@ import CVMaskElement from './CVMaskElement';
 function CVBaseElement() {
 }
 
+var operationsMap = {
+  1: 'source-in',
+  2: 'source-out',
+  3: 'color',
+  4: 'color',
+};
+
 CVBaseElement.prototype = {
   createElements: function () {},
   initRendererElement: function () {},
   createContainerElements: function () {
+    // If the layer is masked we will use two buffers to store each different states of the drawing
+    // TODO: try to reduce the size of these buffers to the size of the composition contaning the layer
+    // It might be challenging because there layer most likely is transformed in some way
+    if (this.data.tt >= 1) {
+      this.buffers = [];
+      var bufferCanvas = createTag('canvas');
+      bufferCanvas.width = this.globalData.canvasContext.canvas.width;
+      bufferCanvas.height = this.globalData.canvasContext.canvas.height;
+      this.buffers.push(bufferCanvas);
+      var bufferCanvas2 = createTag('canvas');
+      bufferCanvas2.width = this.globalData.canvasContext.canvas.width;
+      bufferCanvas2.height = this.globalData.canvasContext.canvas.height;
+      this.buffers.push(bufferCanvas2);
+    }
     this.canvasContext = this.globalData.canvasContext;
     this.renderableEffectsManager = new CVEffects(this);
   },
@@ -37,19 +59,69 @@ CVBaseElement.prototype = {
       this.maskManager._isFirstFrame = true;
     }
   },
-  renderFrame: function () {
+  prepareLayer: function () {
+    if (this.data.tt >= 1) {
+      var buffer = this.buffers[0];
+      // eslint-disable-next-line no-self-assign
+      buffer.width = buffer.width;
+      var bufferCtx = buffer.getContext('2d');
+      // on the first buffer we store the current state of the global drawing
+      bufferCtx.drawImage(this.canvasContext.canvas, 0, 0);
+      // The next four lines are to clear the canvas
+      // TODO: Check if there is a way to clear the canvas without resetting the transform
+      this.currentTransform = this.canvasContext.getTransform();
+      this.canvasContext.setTransform(1, 0, 0, 1, 0, 0);
+      this.canvasContext.clearRect(0, 0, this.canvasContext.canvas.width, this.canvasContext.canvas.height);
+      this.canvasContext.setTransform(this.currentTransform);
+    }
+  },
+  exitLayer: function () {
+    if (this.data.tt >= 1) {
+      var buffer = this.buffers[1];
+      // eslint-disable-next-line no-self-assign
+      buffer.width = buffer.width;
+      // On the second buffer we store the current state of the global drawing that only contains the content of this layer
+      // (if it is a composition, it also includes the nested layers)
+      var bufferCtx = buffer.getContext('2d');
+      bufferCtx.drawImage(this.canvasContext.canvas, 0, 0);
+      // We clear the canvas again
+      this.canvasContext.setTransform(1, 0, 0, 1, 0, 0);
+      this.canvasContext.clearRect(0, 0, this.canvasContext.canvas.width, this.canvasContext.canvas.height);
+      this.canvasContext.setTransform(this.currentTransform);
+      // We draw the mask
+      const mask = this.comp.getElementById(this.data.tp);
+      mask.renderFrame(true);
+      // We draw the second buffer (that contains the content of this layer)
+      this.canvasContext.setTransform(1, 0, 0, 1, 0, 0);
+      this.canvasContext.globalCompositeOperation = operationsMap[this.data.tt];
+      this.canvasContext.drawImage(buffer, 0, 0);
+      // We finally draw the first buffer (that contains the content of the global drawing)
+      // We use destination-over to draw the global drawing below the current layer
+      this.canvasContext.globalCompositeOperation = 'destination-over';
+      this.canvasContext.drawImage(this.buffers[0], 0, 0);
+      this.canvasContext.setTransform(this.currentTransform);
+      // We reset the globalCompositeOperation to source-over, the standard type of operation
+      this.canvasContext.globalCompositeOperation = 'source-over';
+    }
+  },
+  renderFrame: function (forceRender) {
     if (this.hidden || this.data.hd) {
+      return;
+    }
+    if (this.data.td === 1 && !forceRender) {
       return;
     }
     this.renderTransform();
     this.renderRenderable();
     this.setBlendMode();
     var forceRealStack = this.data.ty === 0;
+    this.prepareLayer();
     this.globalData.renderer.save(forceRealStack);
     this.globalData.renderer.ctxTransform(this.finalTransform.mat.props);
     this.globalData.renderer.ctxOpacity(this.finalTransform.mProp.o.v);
     this.renderInnerContent();
     this.globalData.renderer.restore(forceRealStack);
+    this.exitLayer();
     if (this.maskManager.hasMasks) {
       this.globalData.renderer.restore(true);
     }

--- a/player/js/elements/canvasElements/CVContextData.js
+++ b/player/js/elements/canvasElements/CVContextData.js
@@ -35,4 +35,56 @@ CVContextData.prototype.reset = function () {
   this.cO = 1;
 };
 
+CVContextData.prototype.popTransform = function () {
+  var popped = this.saved[this.cArrPos];
+  var i;
+  var arr = this.cTr.props;
+  for (i = 0; i < 16; i += 1) {
+    arr[i] = popped[i];
+  }
+  return popped;
+};
+
+CVContextData.prototype.popOpacity = function () {
+  var popped = this.savedOp[this.cArrPos];
+  this.cO = popped;
+  return popped;
+};
+
+CVContextData.prototype.pop = function () {
+  this.cArrPos -= 1;
+  var transform = this.popTransform();
+  var opacity = this.popOpacity();
+  return {
+    transform: transform,
+    opacity: opacity,
+  };
+};
+
+CVContextData.prototype.push = function () {
+  var props = this.cTr.props;
+  if (this._length <= this.cArrPos) {
+    this.duplicate();
+  }
+  var i;
+  var arr = this.saved[this.cArrPos];
+  for (i = 0; i < 16; i += 1) {
+    arr[i] = props[i];
+  }
+  this.savedOp[this.cArrPos] = this.cO;
+  this.cArrPos += 1;
+};
+
+CVContextData.prototype.getTransform = function () {
+  return this.cTr;
+};
+
+CVContextData.prototype.getOpacity = function () {
+  return this.cO;
+};
+
+CVContextData.prototype.setOpacity = function (value) {
+  this.cO = value;
+};
+
 export default CVContextData;

--- a/player/js/renderers/BaseRenderer.js
+++ b/player/js/renderers/BaseRenderer.js
@@ -133,6 +133,17 @@ BaseRenderer.prototype.searchExtraCompositions = function (assets) {
   }
 };
 
+BaseRenderer.prototype.getElementById = function (ind) {
+  var i;
+  var len = this.elements.length;
+  for (i = 0; i < len; i += 1) {
+    if (this.elements[i].data.ind === ind) {
+      return this.elements[i];
+    }
+  }
+  return null;
+};
+
 BaseRenderer.prototype.getElementByPath = function (path) {
   var pathValue = path.shift();
   var element;

--- a/player/js/utils/featureSupport.js
+++ b/player/js/utils/featureSupport.js
@@ -2,6 +2,7 @@ const featureSupport = (function () {
   var ob = {
     maskType: true,
     svgLumaHidden: true,
+    offscreenCanvas: typeof OffscreenCanvas !== 'undefined',
   };
   if (/MSIE 10/i.test(navigator.userAgent) || /MSIE 9/i.test(navigator.userAgent) || /rv:11.0/i.test(navigator.userAgent) || /Edge\/\d./i.test(navigator.userAgent)) {
     ob.maskType = false;

--- a/player/js/utils/featureSupport.js
+++ b/player/js/utils/featureSupport.js
@@ -1,9 +1,13 @@
 const featureSupport = (function () {
   var ob = {
     maskType: true,
+    svgLumaHidden: true,
   };
   if (/MSIE 10/i.test(navigator.userAgent) || /MSIE 9/i.test(navigator.userAgent) || /rv:11.0/i.test(navigator.userAgent) || /Edge\/\d./i.test(navigator.userAgent)) {
     ob.maskType = false;
+  }
+  if (/firefox/i.test(navigator.userAgent)) {
+    ob.svgLumaHidden = false;
   }
   return ob;
 }());

--- a/player/js/utils/helpers/assetManager.js
+++ b/player/js/utils/helpers/assetManager.js
@@ -2,7 +2,7 @@ import createTag from './html_elements';
 import createNS from './svg_elements';
 import featureSupport from '../featureSupport';
 
-const assetLoader = (function () {
+var lumaLoader = (function () {
   var id = '__lottie_element_luma_buffer';
   var lumaBuffer = null;
   var lumaBufferCtx = null;
@@ -69,10 +69,27 @@ const assetLoader = (function () {
     lumaBufferCtx.filter = 'url(#' + id + ')';
     return lumaBuffer;
   }
-
   return {
-    loadLumaCanvas: loadLuma,
-    getLumaCanvas: getLuma,
+    load: loadLuma,
+    get: getLuma,
+  };
+});
+
+function createCanvas(width, height) {
+  if (featureSupport.offscreenCanvas) {
+    return new OffscreenCanvas(width, height);
+  }
+  var canvas = createTag('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  return canvas;
+}
+
+const assetLoader = (function () {
+  return {
+    loadLumaCanvas: lumaLoader.load,
+    getLumaCanvas: lumaLoader.get,
+    createCanvas: createCanvas,
   };
 }());
 

--- a/player/js/utils/helpers/assetManager.js
+++ b/player/js/utils/helpers/assetManager.js
@@ -47,7 +47,6 @@ const assetLoader = (function () {
   }
 
   function loadLuma() {
-    console.log('load Luma');
     if (!lumaBuffer) {
       svg = createLumaSvgFilter();
       document.body.appendChild(svg);

--- a/player/js/utils/helpers/assetManager.js
+++ b/player/js/utils/helpers/assetManager.js
@@ -1,0 +1,80 @@
+import createTag from './html_elements';
+import createNS from './svg_elements';
+import featureSupport from '../featureSupport';
+
+const assetLoader = (function () {
+  var id = '__lottie_element_luma_buffer';
+  var lumaBuffer = null;
+  var lumaBufferCtx = null;
+  var svg = null;
+
+  // This alternate solution has a slight delay before the filter is applied, resulting in a flicker on the first frame.
+  // Keeping this here for reference, and in the future, if offscreen canvas supports url filters, this can be used.
+  // For now, neither of them work for offscreen canvas, so canvas workers can't support the luma track matte mask.
+  // Naming it solution 2 to mark the extra comment lines.
+  /*
+  var svgString = [
+    '<svg xmlns="http://www.w3.org/2000/svg">',
+    '<filter id="' + id + '">',
+    '<feColorMatrix type="matrix" color-interpolation-filters="sRGB" values="',
+    '0.3, 0.3, 0.3, 0, 0, ',
+    '0.3, 0.3, 0.3, 0, 0, ',
+    '0.3, 0.3, 0.3, 0, 0, ',
+    '0.3, 0.3, 0.3, 0, 0',
+    '"/>',
+    '</filter>',
+    '</svg>',
+  ].join('');
+  var blob = new Blob([svgString], { type: 'image/svg+xml' });
+  var url = URL.createObjectURL(blob);
+  */
+
+  function createLumaSvgFilter() {
+    var _svg = createNS('svg');
+    var fil = createNS('filter');
+    var matrix = createNS('feColorMatrix');
+    fil.setAttribute('id', id);
+    matrix.setAttribute('type', 'matrix');
+    matrix.setAttribute('color-interpolation-filters', 'sRGB');
+    matrix.setAttribute('values', '0.3, 0.3, 0.3, 0, 0, 0.3, 0.3, 0.3, 0, 0, 0.3, 0.3, 0.3, 0, 0, 0.3, 0.3, 0.3, 0, 0');
+    fil.appendChild(matrix);
+    _svg.appendChild(fil);
+    _svg.setAttribute('id', id + '_svg');
+    if (featureSupport.svgLumaHidden) {
+      _svg.style.display = 'none';
+    }
+    return _svg;
+  }
+
+  function loadLuma() {
+    console.log('load Luma');
+    if (!lumaBuffer) {
+      svg = createLumaSvgFilter();
+      document.body.appendChild(svg);
+      lumaBuffer = createTag('canvas');
+      lumaBufferCtx = lumaBuffer.getContext('2d');
+      // lumaBufferCtx.filter = `url('${url}#__lottie_element_luma_buffer')`; // part of solution 2
+      lumaBufferCtx.filter = 'url(#' + id + ')';
+      lumaBufferCtx.fillStyle = 'rgba(0,0,0,0)';
+      lumaBufferCtx.fillRect(0, 0, 1, 1);
+    }
+  }
+
+  function getLuma(canvas) {
+    if (!lumaBuffer) {
+      loadLuma();
+    }
+    lumaBuffer.width = canvas.width;
+    lumaBuffer.height = canvas.height;
+    // lumaBufferCtx.filter = `url('${url}#__lottie_element_luma_buffer')`; // part of solution 2
+    lumaBufferCtx.filter = 'url(#' + id + ')';
+    return lumaBuffer;
+  }
+
+  return {
+    loadLumaCanvas: loadLuma,
+    getLumaCanvas: getLuma,
+  };
+}());
+
+export default assetLoader;

--- a/player/js/worker_wrapper.js
+++ b/player/js/worker_wrapper.js
@@ -973,15 +973,15 @@ var lottie = (function () {
 
           // Transfer control to offscreen if it's not already
           var transferCanvas = canvas;
-          if ((typeof OffscreenCanvas !== 'undefined')
-            && !(canvas instanceof OffscreenCanvas)
-            && canvas.transferControlToOffscreen) {
-            transferCanvas = canvas.transferControlToOffscreen();
-            animationParams.rendererSettings.canvas = transferCanvas;
-            transferedObjects.push(transferCanvas);
-          } else {
+          if (typeof OffscreenCanvas === 'undefined') {
             animation.canvas = canvas;
             animation.instructionsHandler = createInstructionsHandler(canvas);
+          } else {
+            if (!(canvas instanceof OffscreenCanvas)) {
+              transferCanvas = canvas.transferControlToOffscreen();
+              animationParams.rendererSettings.canvas = transferCanvas;
+            }
+            transferedObjects.push(transferCanvas);
           }
         }
         animations[animationId] = animation;

--- a/player/js/worker_wrapper.js
+++ b/player/js/worker_wrapper.js
@@ -4,9 +4,6 @@ function workerContent() {
 
   var styleProperties = ['width', 'height', 'display', 'transform', 'opacity', 'contentVisibility', 'mix-blend-mode'];
   function createElement(namespace, type) {
-    if (type === 'canvas') {
-      return new OffscreenCanvas(1, 1);
-    }
     var style = {
       serialize: function () {
         var obj = {};
@@ -86,7 +83,7 @@ function workerContent() {
           textContent: this._textContent,
         };
       },
-      getContext: function () { return { fillRect: function () {} }; },
+      getContext: function () { return { fillRect: function () {}, drawImage: function () {} }; },
       addEventListener: function (_, callback) {
         setTimeout(callback, 1);
       },
@@ -120,6 +117,8 @@ function workerContent() {
     getElementsByTagName: function () {
       return [];
     },
+    body: createElement('', 'body'),
+    _isProxy: true,
   };
   /* eslint-enable */
   var lottieInternal = (function () {

--- a/player/js/worker_wrapper.js
+++ b/player/js/worker_wrapper.js
@@ -4,6 +4,9 @@ function workerContent() {
 
   var styleProperties = ['width', 'height', 'display', 'transform', 'opacity', 'contentVisibility', 'mix-blend-mode'];
   function createElement(namespace, type) {
+    if (type === 'canvas') {
+      return new OffscreenCanvas(1, 1);
+    }
     var style = {
       serialize: function () {
         var obj = {};


### PR DESCRIPTION
adds support for track matte masks in the canvas renderer.
Luma masks are not supported in the canvas worker because they need a filter to transform luminance into alpha values, and unfortunately there is no way to apply a filter via url on workers.