### PR TITLE
Fix: Added width/height types in SVGRendererConfig

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -111,6 +111,8 @@ export type SVGRendererConfig = BaseRendererConfig & {
     viewBoxSize?: string;
     focusable?: boolean;
     filterSize?: FilterSizeConfig;
+    width?: string, 
+    height?: string;
 };
 
 export type CanvasRendererConfig = BaseRendererConfig & {


### PR DESCRIPTION
Based on https://github.com/airbnb/lottie-web/issues/2719, I was unable to properly add width and height to the existing SVGRendererConfig. 