### PR TITLE
Fix: added destroy null check

### DIFF
--- a/player/js/renderers/CanvasRendererBase.js
+++ b/player/js/renderers/CanvasRendererBase.js
@@ -273,7 +273,7 @@ CanvasRendererBase.prototype.destroy = function () {
   var i;
   var len = this.layers ? this.layers.length : 0;
   for (i = len - 1; i >= 0; i -= 1) {
-    if (this.elements[i] && this.elements[i].destroy()) {
+    if (this.elements[i] && this.elements[i].destroy) {
       this.elements[i].destroy();
     }
   }

--- a/player/js/renderers/CanvasRendererBase.js
+++ b/player/js/renderers/CanvasRendererBase.js
@@ -273,7 +273,7 @@ CanvasRendererBase.prototype.destroy = function () {
   var i;
   var len = this.layers ? this.layers.length : 0;
   for (i = len - 1; i >= 0; i -= 1) {
-    if (this.elements[i]) {
+    if (this.elements[i] && this.elements[i].destroy()) {
       this.elements[i].destroy();
     }
   }

--- a/player/js/renderers/HybridRendererBase.js
+++ b/player/js/renderers/HybridRendererBase.js
@@ -267,7 +267,9 @@ HybridRendererBase.prototype.destroy = function () {
   var i;
   var len = this.layers ? this.layers.length : 0;
   for (i = 0; i < len; i += 1) {
-    this.elements[i].destroy();
+    if (this.elements[i] && this.elements[i].destroy) {
+      this.elements[i].destroy();
+    }
   }
   this.elements.length = 0;
   this.destroyed = true;

--- a/player/js/renderers/SVGRendererBase.js
+++ b/player/js/renderers/SVGRendererBase.js
@@ -110,7 +110,7 @@ SVGRendererBase.prototype.destroy = function () {
   var i;
   var len = this.layers ? this.layers.length : 0;
   for (i = 0; i < len; i += 1) {
-    if (this.elements[i]) {
+    if (this.elements[i] && this.elements[i].destroy) {
       this.elements[i].destroy();
     }
   }


### PR DESCRIPTION
This pull request solves the `this.elements[i].destroy()` problem.
The program was throwing an error because destroy was missing. therefore I added the check if destroy is available.

` if (this.elements[i] && this.elements[i].destroy) {
      this.elements[i].destroy();
}`

