### PR TITLE
[lottie worker] Add missing resetSegments type for lottie worker

### DIFF
--- a/build/player/lottie_worker.js
+++ b/build/player/lottie_worker.js
@@ -20193,6 +20193,10 @@
       if (animations[payload.id]) {
         animations[payload.id].animation.playSegments(payload.arr, payload.forceFlag);
       }
+    } else if (type === 'resetSegments') {
+      if (animations[payload.id]) {
+        animations[payload.id].animation.resetSegments(payload.forceFlag);
+      }
     } else if (type === 'updateDocumentData') {
       animations[payload.id].animation.updateDocumentData(payload.path, payload.documentData, payload.index);
     }
@@ -20519,6 +20523,15 @@ var lottie = (function () {
           payload: {
             id: animationId,
             arr: arr,
+            forceFlag: forceFlag,
+          },
+        });
+      },
+      resetSegments: function (forceFlag) {
+        workerInstance.postMessage({
+          type: 'resetSegments',
+          payload: {
+            id: animationId,
             forceFlag: forceFlag,
           },
         });


### PR DESCRIPTION
I'm on the latest lottie-web v5.10.2 where I notice `resetSegments` will error out when being used in conjunction with `lottie-worker`: `TypeError: animationItem.resetSegments is not a function`, these additional types should fix that issue.
