### PR TITLE
fix: Null layers cause wrong layer order in hybrid renderer

### DIFF
--- a/player/js/renderers/HybridRendererBase.js
+++ b/player/js/renderers/HybridRendererBase.js
@@ -209,7 +209,7 @@ HybridRendererBase.prototype.addTo3dContainer = function (elem, pos) {
       var nextElement;
       while (j < pos) {
         if (this.elements[j] && this.elements[j].getBaseElement) {
-          nextElement = this.elements[j].getBaseElement();
+          nextElement = this.elements[j].getBaseElement() || nextElement;
         }
         j += 1;
       }


### PR DESCRIPTION
when using hybrid renderer, if a layer is exactly the next one of a null layer, it will show on top but not behind previous ones:

<img width="355" alt="截屏2023-05-04 19 36 36" src="https://user-images.githubusercontent.com/18372620/236193290-98dd9517-5354-4349-9ecb-0569f956fce3.png">

after fix: 

<img width="356" alt="截屏2023-05-04 19 36 48" src="https://user-images.githubusercontent.com/18372620/236193372-9dd97efa-42a0-4239-8776-a271bae3f44c.png">

the demo json is here:  

[test.txt](https://github.com/airbnb/lottie-web/files/11396975/test.txt)

