### PR TITLE
Don't re-add existing styles to SVGShapeElement

### DIFF
--- a/player/js/elements/helpers/TransformElement.js
+++ b/player/js/elements/helpers/TransformElement.js
@@ -53,7 +53,7 @@ TransformElement.prototype = {
         }
       }
     }
-    if (this.finalTransform._matMdf) {
+    if (!this.localTransforms || this.finalTransform._matMdf) {
       this.finalTransform._localMatMdf = this.finalTransform._matMdf;
     }
     if (this.finalTransform._opMdf) {

--- a/player/js/elements/svgElements/SVGShapeElement.js
+++ b/player/js/elements/svgElements/SVGShapeElement.js
@@ -211,6 +211,10 @@ SVGShapeElement.prototype.setElementStyles = function (elementData) {
   var j;
   var jLen = this.stylesList.length;
   for (j = 0; j < jLen; j += 1) {
+    if (arr.indexOf(this.stylesList[j]) !== -1) {
+      continue;
+    }
+
     if (!this.stylesList[j].closed) {
       arr.push(this.stylesList[j]);
     }

--- a/player/js/elements/svgElements/SVGShapeElement.js
+++ b/player/js/elements/svgElements/SVGShapeElement.js
@@ -211,11 +211,7 @@ SVGShapeElement.prototype.setElementStyles = function (elementData) {
   var j;
   var jLen = this.stylesList.length;
   for (j = 0; j < jLen; j += 1) {
-    if (arr.indexOf(this.stylesList[j]) !== -1) {
-      continue;
-    }
-
-    if (!this.stylesList[j].closed) {
+    if (arr.indexOf(this.stylesList[j]) === -1 && !this.stylesList[j].closed) {
       arr.push(this.stylesList[j]);
     }
   }


### PR DESCRIPTION
When calling `SVGShapeElement.reloadShapes()`, `searchShapes()` will correctly reconcile modified and added shapes and reuse their elements. However, it will call `setElementStyles()`, which will add all style elements unconditionally to `this.stylesList`, even if the styles were already in there, making it grow indefinitely and causing other problems down the line.

Modify `setElementStyles()` to check for the existence of a particular style before adding it.

---

On a semi-related note, I'm calling `reloadShapes()` because dynamic properties (via `addEffect()`) for e.g. a `tr` element in a shape group (`gr`) will not refresh otherwise. If this is not intended, there is possibly a deeper issue (I can provide a repro if that's the case).