### PR TITLE
fix(package.json) :  support esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.12.0",
   "description": "After Effects plugin for exporting animations to SVG + JavaScript or canvas + JavaScript",
   "main": "./build/player/lottie.js",
+  "module": "./build/player/esm/lottie.min.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/airbnb/lottie-web.git"


### PR DESCRIPTION
Package.json currently only specifies a main package entry which points to a UMD file.  The ESM build files are located in ./build/player/esm and should be specified with the "module" option.