### PR TITLE
Fix transform matrix precalculation when adding effects

### DIFF
--- a/player/js/utils/TransformProperty.js
+++ b/player/js/utils/TransformProperty.js
@@ -126,7 +126,10 @@ const TransformPropertyFactory = (function () {
   }
 
   function precalculateMatrix() {
-    if (!this.a.k) {
+    this.appliedTransformations = 0;
+    this.pre.reset();
+
+    if (!this.a.effectsSequence.length) {
       this.pre.translate(-this.a.v[0], -this.a.v[1], this.a.v[2]);
       this.appliedTransformations = 1;
     } else {


### PR DESCRIPTION
The transform matrix might be precalculated again when effects are added to various properties of the transform. However, the matrix was not being reset to identity, and the appliedTransformations member was not being reset to 0, which caused components of the transform to be applied multiple times.

(To reproduce: create an animation, and at a later time, apply an effect to the rotation using transform.r.addEffect(). Observe how the object gets a rotation that is the sum of the initial value and the one returned from the effect, when it should just be the value returned to the effect.)

Additionally, for the anchor point property, its eligibility for precalculation was checked only by considering whether it's keyframed, when it also could have had an effects sequence added.

(To reproduce: create an animation, and at a later time, apply an effect to the anchor point via transform.a.addEffect(). Observe how the effect does nothing, as the anchor point would still end up precalculated.)