### PR TITLE
Fix hidden styles being reset to visible

### DIFF
--- a/player/js/elements/svgElements/SVGShapeElement.js
+++ b/player/js/elements/svgElements/SVGShapeElement.js
@@ -255,7 +255,7 @@ SVGShapeElement.prototype.searchShapes = function (arr, itemsData, prevViewData,
       if (!processedPos) {
         itemsData[i] = this.createStyleElement(arr[i], level);
       } else {
-        itemsData[i].style.closed = false;
+        itemsData[i].style.closed = arr[i].hd;
       }
       if (arr[i]._render) {
         if (itemsData[i].style.pElem.parentNode !== container) {


### PR DESCRIPTION
In `searchShapes()`, if we found a matching element for a style in `this.processedElements()`, we would reset its `closed` property to `false` always, even if the element is hidden. Instead, set it to the value of the `hd` property to ensure that hidden styles are not re-rendered when an update occurs (e.g. via `reloadShapes()`, see #2983).