### PR TITLE
Fix for text without animation not rendering as a single tspan

### DIFF
--- a/player/js/elements/svgElements/SVGTextElement.js
+++ b/player/js/elements/svgElements/SVGTextElement.js
@@ -6,12 +6,12 @@ import {
 } from '../../utils/helpers/arrays';
 import createNS from '../../utils/helpers/svg_elements';
 import BaseElement from '../BaseElement';
+import ITextElement from '../TextElement';
+import FrameElement from '../helpers/FrameElement';
+import HierarchyElement from '../helpers/HierarchyElement';
+import RenderableDOMElement from '../helpers/RenderableDOMElement';
 import TransformElement from '../helpers/TransformElement';
 import SVGBaseElement from './SVGBaseElement';
-import HierarchyElement from '../helpers/HierarchyElement';
-import FrameElement from '../helpers/FrameElement';
-import RenderableDOMElement from '../helpers/RenderableDOMElement';
-import ITextElement from '../TextElement';
 import SVGCompElement from './SVGCompElement'; // eslint-disable-line
 import SVGShapeElement from './SVGShapeElement';
 
@@ -130,18 +130,18 @@ SVGTextLottieElement.prototype.buildNewText = function () {
     len = textContent.length;
     yPos = documentData.ps ? documentData.ps[1] + documentData.ascent : 0;
     for (i = 0; i < len; i += 1) {
-      tSpan = this.textSpans[i].span || createNS('tspan');
-      tSpan.textContent = textContent[i];
-      tSpan.setAttribute('x', 0);
-      tSpan.setAttribute('y', yPos);
-      tSpan.style.display = 'inherit';
-      tElement.appendChild(tSpan);
       if (!this.textSpans[i]) {
         this.textSpans[i] = {
           span: null,
           glyph: null,
         };
       }
+      tSpan = this.textSpans[i].span || createNS('tspan');
+      tSpan.textContent = textContent[i];
+      tSpan.setAttribute('x', 0);
+      tSpan.setAttribute('y', yPos);
+      tSpan.style.display = 'inherit';
+      tElement.appendChild(tSpan);
       this.textSpans[i].span = tSpan;
       yPos += documentData.finalLineHeight;
     }

--- a/player/js/utils/DataManager.js
+++ b/player/js/utils/DataManager.js
@@ -485,7 +485,7 @@ const dataManager = (function () {
 
           function completeText(data) {
             if (data.t.a.length === 0 && !('m' in data.t.p)) {
-              // data.singleShape = true;
+              data.singleShape = true;
             }
           }
 


### PR DESCRIPTION
This should fix #657 #2358 #2412 #2866 #2961 #3013

This fixes the issue where a piece of text without character-level animation would not render as a single `<tspan>` tag on the DOM, which is a regression on version 5.9.0.

As I mentioned on https://github.com/airbnb/lottie-web/issues/2412#issuecomment-1654745934, it seemed that the piece of code that defined the text as a `singleShape` was commented out, which means the text would never render as a single `<tspan>`.

This is because there was a change to this line:
https://github.com/airbnb/lottie-web/blob/14dc0cb12d17158900165fa5f7beae7d77887029/player/js/elements/svgElements/SVGTextElement.js#L133
`this.textSpans[]` is empty in some cases, which means that `this.textSpans[i].span` doesn't exist, breaking the condition, and then the text wouldn't render.

Seems like this is accounted for with this condition:
https://github.com/airbnb/lottie-web/blob/14dc0cb12d17158900165fa5f7beae7d77887029/player/js/elements/svgElements/SVGTextElement.js#L139-L144

But this comes AFTER the previously mentioned line, which creates the bug.

This PR fixes this issue, and the text renders as a single `<tspan>` again:
![image](https://github.com/airbnb/lottie-web/assets/23201434/8c65873f-4f24-4481-89da-0822d8d5ba7d)
