### PR TITLE
Don't re-add existing styles to SVGShapeElement

### DIFF
--- a/player/js/elements/svgElements/SVGShapeElement.js
+++ b/player/js/elements/svgElements/SVGShapeElement.js
@@ -211,6 +211,10 @@ SVGShapeElement.prototype.setElementStyles = function (elementData) {
   var j;
   var jLen = this.stylesList.length;
   for (j = 0; j < jLen; j += 1) {
+    if (arr.indexOf(this.stylesList[j]) !== -1) {
+      continue;
+    }
+
     if (!this.stylesList[j].closed) {
       arr.push(this.stylesList[j]);
     }

--- a/player/js/elements/svgElements/SVGShapeElement.js
+++ b/player/js/elements/svgElements/SVGShapeElement.js
@@ -211,11 +211,7 @@ SVGShapeElement.prototype.setElementStyles = function (elementData) {
   var j;
   var jLen = this.stylesList.length;
   for (j = 0; j < jLen; j += 1) {
-    if (arr.indexOf(this.stylesList[j]) !== -1) {
-      continue;
-    }
-
-    if (!this.stylesList[j].closed) {
+    if (arr.indexOf(this.stylesList[j]) === -1 && !this.stylesList[j].closed) {
       arr.push(this.stylesList[j]);
     }
   }


### PR DESCRIPTION
*This is a recreation of PR #2983, since that one erroneously used our fork's `master`, which has since gotten additional commits. See that PR for previous discussion.*

When calling `SVGShapeElement.reloadShapes()`, `searchShapes()` will correctly reconcile modified and added shapes and reuse their elements. However, it will call `setElementStyles()`, which will add all style elements unconditionally to `this.stylesList`, even if the styles were already in there, making it grow indefinitely and causing other problems down the line.

Modify `setElementStyles()` to check for the existence of a particular style before adding it.