### PR TITLE
Ensure `_localMatMdf` is reset to `false`

### DIFF
--- a/player/js/elements/helpers/TransformElement.js
+++ b/player/js/elements/helpers/TransformElement.js
@@ -53,7 +53,7 @@ TransformElement.prototype = {
         }
       }
     }
-    if (this.finalTransform._matMdf) {
+    if (!this.localTransforms || this.finalTransform._matMdf) {
       this.finalTransform._localMatMdf = this.finalTransform._matMdf;
     }
     if (this.finalTransform._opMdf) {


### PR DESCRIPTION
With efeb109, support for transform effects has been added, which required introducing another matrix on `TransformElement` to represent the final transform matrix including the effects. This matrix is denoted as `localMat`

If there are no transform effects, `localMat` is the same (referentially) as the existing transform matrix (`mat`). Otherwise, it's calculated by composing the transform effects and then composing that with the "old" transform matrix.

Alongside `localMat`, a `_localMatMdf` member is introduced, which tracks whether the local matrix was modified since its last commit to the DOM, analogously to `_matMdf`.

Unfortunately, a logic bug introduced by efeb109 meant that, in the absence of transform effects, `_localMatMdf` was latched to `true`, i.e. no code path would ever be able to reset it to `false` after it was once set to `true` (e.g. as a result of the matrix being animated).

This causes a serious performance regression, since all matrices that once had `_matMdf` set to `true` will keep being updated in the DOM every frame, causing costly full style recalculations.

Fix by forcing `_matMdf` and `_localMatMdf` to be equivalent in the case of no transform effects, just as `mat` and `localMat` are referentially equal. In the case of >0 transform effects, the custom logic in `renderLocalTransform()` will take over and compute `_localMatMdf` separately from and based on `_matMdf`.

**Affected versions: `lottie-web@5.12.0` to latest**