### PR TITLE
Add `runExpressions` type in `rendererSettings`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -99,6 +99,7 @@ export type AnimationItem = {
 export type BaseRendererConfig = {
     imagePreserveAspectRatio?: string;
     className?: string;
+    runExpressions?: boolean;
 };
 
 export type SVGRendererConfig = BaseRendererConfig & {


### PR DESCRIPTION
Expose `runExpressions` type in `rendererSettings` to fix this error:
![Screenshot 2023-12-06 at 2 06 00 PM](https://github.com/airbnb/lottie-web/assets/69068610/3e4b9b78-77e7-4bb2-bd00-f081c9567839)
`runExpressions` was implemented [here](https://github.com/airbnb/lottie-web/pull/2833).