### PR TITLE
fix: reset _identityCalculated on clone

### DIFF
--- a/player/js/3rd_party/transformation-matrix.js
+++ b/player/js/3rd_party/transformation-matrix.js
@@ -255,6 +255,9 @@ const Matrix = (function () {
     for (i = 0; i < 16; i += 1) {
       matr.props[i] = this.props[i];
     }
+    if (typeof matr._identityCalculated === 'boolean') {
+      matr._identityCalculated = false;
+    }
     return matr;
   }
 
@@ -263,6 +266,7 @@ const Matrix = (function () {
     for (i = 0; i < 16; i += 1) {
       this.props[i] = props[i];
     }
+    this._identityCalculated = false;
   }
 
   function applyToPoint(x, y, z) {


### PR DESCRIPTION
The `_identityCalculated` flag should be reset after calling matrix clone methods, which fixes the following animation issue using CanvasRenderer.

[mask_transform_error.zip](https://github.com/airbnb/lottie-web/files/13701906/mask_transform_error.zip)
