### PR TITLE
feat(types): added dpr setting to ts definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -118,6 +118,7 @@ export type CanvasRendererConfig = BaseRendererConfig & {
     context?: CanvasRenderingContext2D;
     progressiveLoad?: boolean;
     preserveAspectRatio?: string;
+    dpr?: number;
 };
 
 export type HTMLRendererConfig = BaseRendererConfig & {


### PR DESCRIPTION
Canvas renderer supports dpr setting, but it is not defined
https://github.com/airbnb/lottie-web/blob/b32aa832c46ac6fc60d22dada836f0ad92cfbe56/player/js/renderers/CanvasRenderer.js#L22

This PR solves this issue