### PR TITLE
Fix minified worker module

### DIFF
--- a/player/js/worker_wrapper.js
+++ b/player/js/worker_wrapper.js
@@ -263,6 +263,7 @@ function workerContent() {
     return new ProxyElement(type, namespace);
   }
 
+  var module; // eslint-disable-line no-redeclare, no-unused-vars
   var window = self; // eslint-disable-line no-redeclare, no-unused-vars
 
   var document = { // eslint-disable-line no-redeclare


### PR DESCRIPTION
This PR attempts to fix minified code for the worker module.

Issue: #2748

The problem here is that the final worker code is transformed into an UMD module that defines the `module` variable.
The internal Lottie code runs in the worker, but it is loaded using `toString` on a function that is affected by minification. When the minifier run, it thinks module is defined and then remove any other check.
This PR resets the `module` variabile definition in the wrapper.

it ss a kind of workaround, but I think is safer than rewriting the whole Lottie module system 😅 