### PR TITLE
fix: Avoid desync between start and end (outer and inner) radial gradient circles 

### DIFF
--- a/player/js/elements/helpers/shapes/SVGElementsRenderer.js
+++ b/player/js/elements/helpers/shapes/SVGElementsRenderer.js
@@ -186,7 +186,7 @@ const SVGElementsRenderer = (function () {
           itemData.of.setAttribute('r', rad);
         }
       }
-      if (itemData.e._mdf || itemData.h._mdf || itemData.a._mdf || isFirstFrame) {
+      if (itemData.s._mdf || itemData.e._mdf || itemData.h._mdf || itemData.a._mdf || isFirstFrame) {
         if (!rad) {
           rad = Math.sqrt(Math.pow(pt1[0] - pt2[0], 2) + Math.pow(pt1[1] - pt2[1], 2));
         }


### PR DESCRIPTION
Due to the way `_mdf` (modified) flags are checked in `SVGElementsRenderer.renderGradient()`, it's possible that the `fx` and `fy` components of a radial gradient, defining its "inner" circle (used for highlights via `.h` and `.a` members of a `gf` shape element in the Lottie JSON), fall out of sync with `cx` and `cy` which define its outer circle.

In particular, the branch which sets `fx`/`fy` triggers only when the gradient end point changes, but then sets `fx` and `fy` based on a calculation that involves both the start and end points. Therefore, if the start point of a gradient ever changes without a corresponding change in the end point, the `cx`/`cy` value will be updated but not the `fx`/`fy` value, causing visual artifacts.

File exhibiting issue:  [radial-gradient-repro.json](https://github.com/user-attachments/files/16753102/radial-gradient-repro.json)

Current rendering:
![radial-gradient-repro-broken](https://github.com/user-attachments/assets/60d786b0-ad29-4205-bfa0-ab8c79b12509)

After fix:
![radial-gradient-repro-fixed](https://github.com/user-attachments/assets/21beb778-7102-4d53-9704-91fb511228c1)
