### PR TITLE
HTML rendered output does not match the desired result

### DIFF
--- a/player/js/renderers/HybridRendererBase.js
+++ b/player/js/renderers/HybridRendererBase.js
@@ -208,7 +208,7 @@ HybridRendererBase.prototype.addTo3dContainer = function (elem, pos) {
       var j = this.threeDElements[i].startPos;
       var nextElement;
       while (j < pos) {
-        if (this.elements[j] && this.elements[j].getBaseElement) {
+        if (this.elements[j] && this.elements[j] !== true && this.elements[j].getBaseElement()) {
           nextElement = this.elements[j].getBaseElement();
         }
         j += 1;


### PR DESCRIPTION
When using an HTML renderer, the lack of empty node filtering can lead to animation rendering anomalies where used empty nodes cannot find adjacent nodes when inserted into the DOM view, resulting in layer misalignment.