### PR TITLE
Add SVGShapeElement sourceRectAtTime calculation

### DIFF
--- a/player/js/elements/svgElements/SVGShapeElement.js
+++ b/player/js/elements/svgElements/SVGShapeElement.js
@@ -65,6 +65,25 @@ SVGShapeElement.prototype.createContent = function () {
   this.filterUniqueShapes();
 };
 
+SVGShapeElement.prototype.sourceRectAtTime = function () {
+  var largestBox = {
+    width: 0, height: 0, x: 0, y: 0,
+  };
+  var largestArea = 0;
+  this.stylesList.forEach((style) => {
+    const bbox = style.pElem.getBBox();
+    var area = bbox.width * bbox.height;
+    if (area > largestArea) largestBox = bbox;
+  });
+
+  return {
+    left: largestBox.x,
+    top: largestBox.y,
+    width: largestBox.width,
+    height: largestBox.height,
+  };
+};
+
 /*
 This method searches for multiple shapes that affect a single element and one of them is animated
 */


### PR DESCRIPTION
Tested with the following composition, where the red box is setting scale from the shape layer's sourceRectAtTime and the text is reading out the sourceRectAtTime width of the shape layer.

Might not catch all use cases but for us this makes the expression function usable.

AE:
![Screenshot 2024-11-22 164356](https://github.com/user-attachments/assets/85f8733e-17af-4c30-924b-111169fe8928)

Pre-fix lottie output:
![Screenshot 2024-11-22 164535](https://github.com/user-attachments/assets/378fbd37-4d77-409a-a9cc-dbd0208fa135)

Post-fix lottie output:
![Screenshot 2024-11-22 164406](https://github.com/user-attachments/assets/176c5c8b-54d1-4af8-99ac-3c503d4a4c1c)

Fixes #2779
Fixes #2420

Related #1984

EDIT: here's the exported comp:
[Comp 3.json](https://github.com/user-attachments/files/17880010/Comp.3.json)
