### PR TITLE
Fix: Not collapsable gradients with canvas renderer

### DIFF
--- a/player/js/elements/canvasElements/CVShapeElement.js
+++ b/player/js/elements/canvasElements/CVShapeElement.js
@@ -477,15 +477,24 @@ CVShapeElement.prototype.renderGradientFill = function (styleData, itemData, gro
     }
 
     var i;
-    var len = styleData.g.p;
-    var cValues = itemData.g.c;
-    var opacity = 1;
-
-    for (i = 0; i < len; i += 1) {
-      if (itemData.g._hasOpacity && itemData.g._collapsable) {
-        opacity = itemData.g.o[i * 2 + 1];
+    var len;
+    if (!itemData.g._hasOpacity || itemData.g._collapsable) {
+      len = styleData.g.p;
+      var cValues = itemData.g.c;
+      var opacity = 1;
+      for (i = 0; i < len; i += 1) {
+        if (itemData.g._hasOpacity) {
+          opacity = itemData.g.o[i * 2 + 1];
+        }
+        grd.addColorStop(cValues[i * 4] / 100, 'rgba(' + cValues[i * 4 + 1] + ',' + cValues[i * 4 + 2] + ',' + cValues[i * 4 + 3] + ',' + opacity + ')');
       }
-      grd.addColorStop(cValues[i * 4] / 100, 'rgba(' + cValues[i * 4 + 1] + ',' + cValues[i * 4 + 2] + ',' + cValues[i * 4 + 3] + ',' + opacity + ')');
+    } else {
+      itemData.g.mergeStops();
+      len = itemData.g._mergedStopsLen;
+      var stops = itemData.g._mergedStops;
+      for (i = 0; i < len; i += 1) {
+        grd.addColorStop(stops[i][0] / 100, 'rgba(' + stops[i][1] + ',' + stops[i][2] + ',' + stops[i][3] + ',' + stops[i][4] / 255 + ')');
+      }
     }
     styleElem.grd = grd;
   }

--- a/player/js/utils/PolynomialBezier.js
+++ b/player/js/utils/PolynomialBezier.js
@@ -1,13 +1,13 @@
+import {
+  lerp,
+} from './common';
+
 function floatEqual(a, b) {
   return Math.abs(a - b) * 100000 <= Math.min(Math.abs(a), Math.abs(b));
 }
 
 function floatZero(f) {
   return Math.abs(f) <= 0.00001;
-}
-
-function lerp(p0, p1, amount) {
-  return p0 * (1 - amount) + p1 * amount;
 }
 
 function lerpPoint(p0, p1, amount) {

--- a/player/js/utils/common.js
+++ b/player/js/utils/common.js
@@ -229,6 +229,17 @@ const rgbToHex = (function () {
   };
 }());
 
+function lerp(p0, p1, factor) {
+  return p0 * (1 - factor) + p1 * factor;
+}
+
+function lerpFactor(p0, p1, p) {
+  if (p1 === p0) {
+    return 0.5; // Any value between 0 and 1 is technically correct
+  }
+  return (p - p0) / (p1 - p0);
+}
+
 const setSubframeEnabled = (flag) => { subframeEnabled = !!flag; };
 const getSubframeEnabled = () => subframeEnabled;
 const setExpressionsPlugin = (value) => { expressionsPlugin = value; };
@@ -273,6 +284,8 @@ export {
   addBrightnessToRGB,
   addHueToRGB,
   rgbToHex,
+  lerp,
+  lerpFactor,
   setIdPrefix,
   getIdPrefix,
   BMMath,

--- a/player/js/utils/shapes/GradientProperty.js
+++ b/player/js/utils/shapes/GradientProperty.js
@@ -6,6 +6,7 @@ import {
   createTypedArray,
 } from '../helpers/arrays';
 import PropertyFactory from '../PropertyFactory';
+import { lerp, lerpFactor } from '../common';
 
 function GradientProperty(elem, data, container) {
   this.data = data;
@@ -53,6 +54,97 @@ GradientProperty.prototype.checkCollapsable = function () {
     return false;
   }
   return true;
+};
+
+const firstValueCmp = (a, b) => a[0] - b[0];
+
+GradientProperty.prototype.mergeStops = function () {
+  var len = this.data.p;
+  var i = 0;
+
+  if (this._mergedStops === undefined) {
+    this._cSorted = new Array(len);
+    this._oSorted = new Array(len);
+    this._mergedStops = new Array(len * 2);
+
+    for (i = 0; i < len; i += 1) {
+      this._cSorted[i] = createTypedArray('uint8c', 4);
+      this._oSorted[i] = createTypedArray('uint8c', 2);
+      this._mergedStops[i * 2] = createTypedArray('uint8c', 5);
+      this._mergedStops[i * 2 + 1] = createTypedArray('uint8c', 5);
+    }
+  }
+
+  var cValues = this.c;
+  var oValues = this.o;
+  var cSorted = this._cSorted;
+  var oSorted = this._oSorted;
+  var stops = this._mergedStops;
+
+  for (i = 0; i < len; i += 1) {
+    cSorted[i][0] = cValues[i * 4];
+    cSorted[i][1] = cValues[i * 4 + 1];
+    cSorted[i][2] = cValues[i * 4 + 2];
+    cSorted[i][3] = cValues[i * 4 + 3];
+
+    oSorted[i][0] = Math.round(oValues[i * 2]);
+    oSorted[i][1] = Math.round(oValues[i * 2 + 1] * 255);
+  }
+  cSorted.sort(firstValueCmp);
+  oSorted.sort(firstValueCmp);
+
+  i = 0;
+  var ci = 0;
+  var oi = 0;
+  var factor;
+  while (ci < len || oi < len) {
+    if (oi === len || (ci < len && cSorted[ci][0] < oSorted[oi][0])) {
+      stops[i][0] = cSorted[ci][0];
+      stops[i][1] = cSorted[ci][1];
+      stops[i][2] = cSorted[ci][2];
+      stops[i][3] = cSorted[ci][3];
+      if (oi === 0) {
+        stops[i][4] = oSorted[0][1];
+      } else if (oi === len) {
+        stops[i][4] = oSorted[len - 1][1];
+      } else {
+        factor = lerpFactor(oSorted[oi - 1][0], oSorted[oi][0], cSorted[ci][0]);
+        stops[i][4] = lerp(oSorted[oi - 1][1], oSorted[oi][1], factor);
+      }
+      ci += 1;
+      i += 1;
+    } else if (ci === len || cSorted[ci][0] > oSorted[oi][0]) {
+      stops[i][0] = oSorted[oi][0];
+      stops[i][4] = oSorted[oi][1];
+
+      if (ci === 0) {
+        stops[i][1] = cSorted[0][1];
+        stops[i][2] = cSorted[0][2];
+        stops[i][3] = cSorted[0][3];
+      } else if (ci === len) {
+        stops[i][1] = cSorted[len - 1][1];
+        stops[i][2] = cSorted[len - 1][2];
+        stops[i][3] = cSorted[len - 1][3];
+      } else {
+        factor = lerpFactor(cSorted[ci - 1][0], cSorted[ci][0], oSorted[oi][0]);
+        stops[i][1] = lerp(cSorted[ci - 1][1], cSorted[ci][1], factor);
+        stops[i][2] = lerp(cSorted[ci - 1][2], cSorted[ci][2], factor);
+        stops[i][3] = lerp(cSorted[ci - 1][3], cSorted[ci][3], factor);
+      }
+      oi += 1;
+      i += 1;
+    } else if (cSorted[ci][0] === oSorted[oi][0]) {
+      stops[i][0] = cSorted[ci][0];
+      stops[i][1] = cSorted[ci][1];
+      stops[i][2] = cSorted[ci][2];
+      stops[i][3] = cSorted[ci][3];
+      stops[i][4] = oSorted[oi][1];
+      ci += 1;
+      oi += 1;
+      i += 1;
+    }
+  }
+  this._mergedStopsLen = i;
 };
 
 GradientProperty.prototype.getValue = function (forceRender) {


### PR DESCRIPTION
When gradient color stops offsets do not align with alpha stops offsets, Canvas renderer just renders without using alpha at all. This PR uses algorithm that merges colors and alpha stops into single array of colors with alpha that correctly represents such gradient and can be used with CanvasGradient.
Example animation that is rendered differently with canvas renderer: [break.json](https://github.com/user-attachments/files/18663201/break.json)
