### PR TITLE
Expose a `lottie-web/light` version of the player

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,21 @@
   "version": "5.13.0",
   "description": "After Effects plugin for exporting animations to SVG + JavaScript or canvas + JavaScript",
   "main": "./build/player/lottie.js",
+  "exports": {
+    ".": {
+      "types": "./build/player/lottie.d.ts",
+      "import": "./build/player/esm/lottie.min.js",
+      "require": "./build/player/cjs/lottie.min.js",
+      "default": "./build/player/lottie.js"
+    },
+    "./light": {
+      "types": "./build/player/lottie_light.d.ts",
+      "import": "./build/player/esm/lottie_light.min.js",
+      "require": "./build/player/cjs/lottie_light.min.js",
+      "default": "./build/player/lottie_light.js"
+    },
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/airbnb/lottie-web.git"


### PR DESCRIPTION
The `lottie-web` library is being built in several variants:
- light or not
- worker or not
- all renderers, or svg renderer, or html renderer, or canvas renderer
- ESM or CJS or UMD

but these versions aren't exported from the package, which only exposes `"main": "./build/player/lottie.js",` (not light, not worker, all renderers, UMD).

This PR proposes that we take advantage of the different builds to expose more versions using the standardized `package.json#exports` field.

In this 1st proposal,
- we keep the `.` export (i.e. `import Lottie from 'lottie-web'`) as the "not light, not worker, all renderers" version, but expose the ESM, CJS and AMD variants through the same export
- we add a `/light` export (i.e. `import Lottie from 'lottie-web/light'`) as another version: "light, not worker, svg renderer".

This change should have no impact on the maintenance burden of this package as it does not introduce new code, new tooling, or new build pipelines / artefacts. It only takes advantage of already existing files. 

If the idea is liked, we could imagine introducing other exports for 
- canvas
- html
- light-canvas
- light-html
- svg
- canvas-worker (UMD only)
- worker (UMD only)