### PR TITLE
Lazy instantiation of `proxyImage` canvas fallback

### DIFF
--- a/player/js/utils/imagePreloader.js
+++ b/player/js/utils/imagePreloader.js
@@ -4,15 +4,18 @@ import dataManager from './DataManager';
 import createTag from './helpers/html_elements';
 
 const ImagePreloader = (function () {
-  var proxyImage = (function () {
+  var proxyImage; 
+  function getProxyImage() {
+    if (proxyImage) return proxyImage;
     var canvas = createTag('canvas');
     canvas.width = 1;
     canvas.height = 1;
     var ctx = canvas.getContext('2d');
     ctx.fillStyle = 'rgba(0,0,0,0)';
     ctx.fillRect(0, 0, 1, 1);
+    proxyImage = canvas;
     return canvas;
-  }());
+  }
 
   function imageLoaded() {
     this.loadedAssets += 1;
@@ -70,7 +73,7 @@ const ImagePreloader = (function () {
       img.addEventListener('load', this._imageLoaded, false);
     }
     img.addEventListener('error', function () {
-      ob.img = proxyImage;
+      ob.img = getProxyImage();
       this._imageLoaded();
     }.bind(this), false);
     img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', path);
@@ -92,7 +95,7 @@ const ImagePreloader = (function () {
     img.crossOrigin = 'anonymous';
     img.addEventListener('load', this._imageLoaded, false);
     img.addEventListener('error', function () {
-      ob.img = proxyImage;
+      ob.img = getProxyImage();
       this._imageLoaded();
     }.bind(this), false);
     img.src = path;


### PR DESCRIPTION
The `ImagePreloader` is eagerly instantiated when the lottie-web module is imported. And itself creates a `proxyImage` that is a 1x1 transparent canvas used as a fallback when image loading yields an error.

As such, this `proxyImage` is likely rarely used as (we hope) most images load fine.

This PR proposes we lazy instantiate this `canvas`, waiting to actually need it. This should
- make the module start up time (very very very) slightly better
- make the module RAM consumption (very very) slightly better
- remove 1 of the issues encountered during server-side rendering (as we're not calling `document.createElement('canvas')` at import-time anymore)

---

In combination with https://github.com/airbnb/lottie-web/pull/3164, this could solve the issue reported in https://github.com/airbnb/lottie-web/issues/3047