### PR TITLE
fix: avoid infinite loop in isShapeInAnimatedModifiers using .some()

### DIFF
--- a/player/js/elements/ShapeElement.js
+++ b/player/js/elements/ShapeElement.js
@@ -12,14 +12,9 @@ IShapeElement.prototype = {
     }
   },
   isShapeInAnimatedModifiers: function (data) {
-    var i = 0;
-    var len = this.shapeModifiers.length;
-    while (i < len) {
-      if (this.shapeModifiers[i].isAnimatedWithShape(data)) {
-        return true;
-      }
-    }
-    return false;
+    return this.shapeModifiers.some(function (mod) {
+      return mod.isAnimatedWithShape(data);
+    });
   },
   renderModifiers: function () {
     if (!this.shapeModifiers.length) {


### PR DESCRIPTION
### What this does
Avoids the infinite loop in `isShapeInAnimatedModifiers` caused by missing increment in manual `while` loop

### Changes
- Replaced `while` loop with `Array.prototype.some()` method  for safe short-circuiting
- Maintains same functionality with cleaner, more readable code
- ES5 compatible

### Issue
Closes #2859

### Reference
Related to discussion [#2925](https://github.com/airbnb/lottie-web/pull/2925) , which addressed similar behavior but not updated to ShapeElement.js and didn't refactor using `.some()` 