### PR TITLE
feat(*): add support for blur filter in canvas renderer

### DIFF
--- a/player/js/elements/canvasElements/CVEffects.js
+++ b/player/js/elements/canvasElements/CVEffects.js
@@ -19,13 +19,25 @@ function CVEffects(elem) {
   if (this.filters.length) {
     elem.addRenderableComponent(this);
   }
+  this.globalData = elem.globalData;
 }
 
 CVEffects.prototype.renderFrame = function (_isFirstFrame) {
   var i;
   var len = this.filters.length;
+  var filterStrings = [];
+
   for (i = 0; i < len; i += 1) {
     this.filters[i].renderFrame(_isFirstFrame);
+    if (this.filters[i].filterString) {
+      filterStrings.push(this.filters[i].filterString);
+    }
+  }
+
+  var canvasContext = this.globalData.canvasContext;
+
+  if (canvasContext && filterStrings.length > 0) {
+    canvasContext.filter = filterStrings.join(' ');
   }
 };
 

--- a/player/js/elements/canvasElements/effects/CVGaussianBlurEffect.js
+++ b/player/js/elements/canvasElements/effects/CVGaussianBlurEffect.js
@@ -1,0 +1,33 @@
+function CVGaussianBlurEffect(effectsManager, elem) {
+  this.filterManager = effectsManager;
+  this.elem = elem;
+  this.globalData = elem.globalData;
+}
+
+CVGaussianBlurEffect.prototype.renderFrame = function () {
+  var scale = this.globalData.transformCanvas.sx;
+  // Empirical value, matching AE's blur appearance.
+  var kBlurrinessToSigma = 0.3;
+  var sigma = this.filterManager.effectElements[0].p.v * kBlurrinessToSigma * scale;
+
+  // Dimensions mapping:
+  //
+  //   1 -> horizontal & vertical
+  //   2 -> horizontal only
+  //   3 -> vertical only
+  //
+  var dimensions = this.filterManager.effectElements[1].p.v;
+  var sigmaX = (dimensions == 3) ? 0 : sigma; // eslint-disable-line eqeqeq
+  var sigmaY = (dimensions == 2) ? 0 : sigma; // eslint-disable-line eqeqeq
+
+  // Store filter string for combination with other effects
+  if (sigmaX > 0 || sigmaY > 0) {
+    // Canvas filter doesn't support separate X/Y blur like SVG, use maximum sigma
+    var blurRadius = Math.max(sigmaX, sigmaY);
+    this.filterString = 'blur(' + blurRadius + 'px)';
+  } else {
+    this.filterString = '';
+  }
+};
+
+export default CVGaussianBlurEffect;

--- a/player/js/modules/canvas.js
+++ b/player/js/modules/canvas.js
@@ -8,6 +8,7 @@ import interfacesProvider from '../utils/expressions/InterfacesProvider';
 import expressionPropertyDecorator from '../utils/expressions/ExpressionPropertyDecorator';
 import expressionTextPropertyDecorator from '../utils/expressions/ExpressionTextPropertyDecorator';
 import CVTransformEffect from '../elements/canvasElements/effects/CVTransformEffect';
+import CVGaussianBlurEffect from '../elements/canvasElements/effects/CVGaussianBlurEffect';
 import { registerEffect } from '../elements/canvasElements/CVEffects';
 
 // Registering expression plugin
@@ -15,6 +16,7 @@ setExpressionsPlugin(Expressions);
 setExpressionInterfaces(interfacesProvider);
 expressionPropertyDecorator();
 expressionTextPropertyDecorator();
+registerEffect(29, CVGaussianBlurEffect);
 registerEffect(35, CVTransformEffect);
 
 export default lottie;

--- a/player/js/modules/full.js
+++ b/player/js/modules/full.js
@@ -32,6 +32,7 @@ import SVGMatte3Effect from '../elements/svgElements/effects/SVGMatte3Effect';
 import SVGGaussianBlurEffect from '../elements/svgElements/effects/SVGGaussianBlurEffect';
 import SVGTransformEffect from '../elements/svgElements/effects/SVGTransformEffect';
 import CVTransformEffect from '../elements/canvasElements/effects/CVTransformEffect';
+import CVGaussianBlurEffect from '../elements/canvasElements/effects/CVGaussianBlurEffect';
 import { registerEffect as canvasRegisterEffect } from '../elements/canvasElements/CVEffects';
 
 // Registering renderers
@@ -63,6 +64,7 @@ registerEffect(25, SVGDropShadowEffect, true);
 registerEffect(28, SVGMatte3Effect, false);
 registerEffect(29, SVGGaussianBlurEffect, true);
 registerEffect(35, SVGTransformEffect, false);
+canvasRegisterEffect(29, CVGaussianBlurEffect);
 canvasRegisterEffect(35, CVTransformEffect);
 
 export default lottie;


### PR DESCRIPTION
Currently, the canvas renderer does not support the blur effect.

Before
<img width="714" height="399" alt="Screenshot 2026-01-10 at 03 31 07" src="https://github.com/user-attachments/assets/2d21293e-30ed-45ab-8680-c8e322f55779" />

After
<img width="715" height="401" alt="Screenshot 2026-01-10 at 03 32 19" src="https://github.com/user-attachments/assets/acd1f1f6-ab35-4aff-a640-9c146b8d9d9a" />

Here, I’m using ctx.filter = 'blur(20px)'. I also experimented with ctx.filter = 'url(#svgFilter)', and that works as well.

https://github.com/airbnb/lottie-web/compare/master...stepancar:lottie-web:feat/blur-filter?expand=1

The only issue with that approach is that scaling becomes tricky, so I decided to go with the simpler solution as a first step.