### PR TITLE
perf(canvas): decouple canvas builds from the SVG element tree

### DIFF
--- a/player/js/elements/canvasElements/CVImageElement.js
+++ b/player/js/elements/canvasElements/CVImageElement.js
@@ -8,8 +8,7 @@ import TransformElement from '../helpers/TransformElement';
 import HierarchyElement from '../helpers/HierarchyElement';
 import FrameElement from '../helpers/FrameElement';
 import CVBaseElement from './CVBaseElement';
-import IImageElement from '../ImageElement';
-import SVGShapeElement from '../svgElements/SVGShapeElement';
+import RenderableDOMElement from '../helpers/RenderableDOMElement';
 
 function CVImageElement(data, globalData, comp) {
   this.assetData = globalData.getAssetData(data.refId);
@@ -18,8 +17,8 @@ function CVImageElement(data, globalData, comp) {
 }
 extendPrototype([BaseElement, TransformElement, CVBaseElement, HierarchyElement, FrameElement, RenderableElement], CVImageElement);
 
-CVImageElement.prototype.initElement = SVGShapeElement.prototype.initElement;
-CVImageElement.prototype.prepareFrame = IImageElement.prototype.prepareFrame;
+CVImageElement.prototype.initElement = RenderableDOMElement.prototype.initElement;
+CVImageElement.prototype.prepareFrame = RenderableDOMElement.prototype.prepareFrame;
 
 CVImageElement.prototype.createContent = function () {
   if (this.img.width && (this.assetData.w !== this.img.width || this.assetData.h !== this.img.height)) {

--- a/player/js/elements/canvasElements/CVSolidElement.js
+++ b/player/js/elements/canvasElements/CVSolidElement.js
@@ -7,16 +7,15 @@ import TransformElement from '../helpers/TransformElement';
 import HierarchyElement from '../helpers/HierarchyElement';
 import FrameElement from '../helpers/FrameElement';
 import CVBaseElement from './CVBaseElement';
-import IImageElement from '../ImageElement';
-import SVGShapeElement from '../svgElements/SVGShapeElement';
+import RenderableDOMElement from '../helpers/RenderableDOMElement';
 
 function CVSolidElement(data, globalData, comp) {
   this.initElement(data, globalData, comp);
 }
 extendPrototype([BaseElement, TransformElement, CVBaseElement, HierarchyElement, FrameElement, RenderableElement], CVSolidElement);
 
-CVSolidElement.prototype.initElement = SVGShapeElement.prototype.initElement;
-CVSolidElement.prototype.prepareFrame = IImageElement.prototype.prepareFrame;
+CVSolidElement.prototype.initElement = RenderableDOMElement.prototype.initElement;
+CVSolidElement.prototype.prepareFrame = RenderableDOMElement.prototype.prepareFrame;
 
 CVSolidElement.prototype.renderInnerContent = function () {
   // var ctx = this.canvasContext;

--- a/player/js/renderers/CanvasRendererBase.js
+++ b/player/js/renderers/CanvasRendererBase.js
@@ -5,12 +5,12 @@ import {
   createSizedArray,
 } from '../utils/helpers/arrays';
 import createTag from '../utils/helpers/html_elements';
-import SVGRenderer from './SVGRenderer';
 import BaseRenderer from './BaseRenderer';
 import CVShapeElement from '../elements/canvasElements/CVShapeElement';
 import CVTextElement from '../elements/canvasElements/CVTextElement';
 import CVImageElement from '../elements/canvasElements/CVImageElement';
 import CVSolidElement from '../elements/canvasElements/CVSolidElement';
+import createNull from './createNullElement';
 
 function CanvasRendererBase() {
 }
@@ -32,7 +32,7 @@ CanvasRendererBase.prototype.createSolid = function (data) {
   return new CVSolidElement(data, this.globalData, this);
 };
 
-CanvasRendererBase.prototype.createNull = SVGRenderer.prototype.createNull;
+CanvasRendererBase.prototype.createNull = createNull;
 
 CanvasRendererBase.prototype.ctxTransform = function (props) {
   if (props[0] === 1 && props[1] === 0 && props[4] === 0 && props[5] === 1 && props[12] === 0 && props[13] === 0) {

--- a/player/js/renderers/HybridRendererBase.js
+++ b/player/js/renderers/HybridRendererBase.js
@@ -17,6 +17,7 @@ import HCameraElement from '../elements/htmlElements/HCameraElement';
 import HImageElement from '../elements/htmlElements/HImageElement';
 import ISolidElement from '../elements/SolidElement';
 import SVGTextLottieElement from '../elements/svgElements/SVGTextElement';
+import createNull from './createNullElement';
 
 function HybridRendererBase(animationItem, config) {
   this.animationItem = animationItem;
@@ -126,7 +127,7 @@ HybridRendererBase.prototype.createSolid = function (data) {
   return new HSolidElement(data, this.globalData, this);
 };
 
-HybridRendererBase.prototype.createNull = SVGRenderer.prototype.createNull;
+HybridRendererBase.prototype.createNull = createNull;
 
 HybridRendererBase.prototype.getThreeDContainerByPos = function (pos) {
   var i = 0;

--- a/player/js/renderers/SVGRendererBase.js
+++ b/player/js/renderers/SVGRendererBase.js
@@ -15,16 +15,14 @@ import IImageElement from '../elements/ImageElement';
 import SVGShapeElement from '../elements/svgElements/SVGShapeElement';
 import SVGTextLottieElement from '../elements/svgElements/SVGTextElement'; // eslint-disable-line import/no-cycle
 import ISolidElement from '../elements/SolidElement';
-import NullElement from '../elements/NullElement';
+import createNull from './createNullElement';
 
 function SVGRendererBase() {
 }
 
 extendPrototype([BaseRenderer], SVGRendererBase);
 
-SVGRendererBase.prototype.createNull = function (data) {
-  return new NullElement(data, this.globalData, this);
-};
+SVGRendererBase.prototype.createNull = createNull;
 
 SVGRendererBase.prototype.createShape = function (data) {
   return new SVGShapeElement(data, this.globalData, this);

--- a/player/js/renderers/createNullElement.js
+++ b/player/js/renderers/createNullElement.js
@@ -1,0 +1,13 @@
+import NullElement from '../elements/NullElement';
+
+// Shared `createNull` renderer method. Null layers (`ty: 3`) produce no visual
+// output in any renderer, so every renderer creates the same `NullElement`.
+// Keeping this in its own tiny module lets the canvas renderer reuse it without
+// importing the whole SVG renderer (and the SVG element tree it drags in) just
+// to borrow this one method. Assigned onto renderer prototypes, so it relies on
+// `this` and must stay a regular function.
+function createNull(data) {
+  return new NullElement(data, this.globalData, this);
+}
+
+export default createNull;


### PR DESCRIPTION
## Summary

The canvas renderers and canvas layer elements were coupled to the SVG renderer
and SVG element tree purely to **borrow inherited methods**, which dragged the
entire SVG element subtree into every canvas build even though canvas rendering
never uses it. This PR breaks those couplings without changing behavior, so the
SVG element tree no longer reaches the canvas builds.

## Changes

1. **`createNull` extracted to a shared module.** `CanvasRendererBase` and
   `HybridRendererBase` imported the concrete `SVGRenderer` only to reuse
   `createNull` (which is defined on `SVGRendererBase` and just returns a
   `NullElement`). The shared method now lives in `renderers/createNullElement.js`
   and is referenced by `SVGRendererBase`, `CanvasRendererBase`, and
   `HybridRendererBase`. `CanvasRendererBase` no longer imports `SVGRenderer`.

2. **Canvas solid/image layers decoupled from `SVGShapeElement`.**
   `CVSolidElement` and `CVImageElement` borrowed `initElement`/`prepareFrame`
   from `SVGShapeElement` and `ImageElement`, but both methods are inherited from
   `RenderableDOMElement`. They now borrow them directly from
   `RenderableDOMElement`, dropping the SVG element tree (`SVGShapeElement`,
   `SVGElementsRenderer`, `SVGBaseElement`, `SVGEffects`, gradient/style data, ...)
   from the canvas graph.

## No behavioral change

Every change re-points an assignment to the **same underlying function
reference** (the methods were already inherited from the shared bases via
`extendPrototype`). No method bodies change; null/solid/image layers render
exactly as before.

## Size impact (gzip)

| Build | before | after | delta |
| --- | ---: | ---: | ---: |
| `lottie_light_canvas.min.js` | 54,808 | 47,622 | **−7,186 (−13.1%)** |
| `lottie_canvas.min.js` | 68,250 | 60,719 | **−7,531 (−11.0%)** |

(Raw: −28.8 KB and −32.1 KB respectively.)

## Notes

- Source-only PR; the regenerated `build/` artifacts are intentionally excluded
  to keep the diff reviewable.
- `HybridRendererBase` still imports `SVGRenderer` because the HTML/hybrid
  renderer genuinely uses it elsewhere — only the `createNull` borrow was removed
  there.
